### PR TITLE
[#9] feat - Core Data Model 추가

### DIFF
--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		34B01143290015950043951A /* Extension in Resources */ = {isa = PBXBuildFile; fileRef = 34B01142290015950043951A /* Extension */; };
 		34B011462900159F0043951A /* Resource in Resources */ = {isa = PBXBuildFile; fileRef = 34B011452900159F0043951A /* Resource */; };
 		34B01149290015A60043951A /* Model in Resources */ = {isa = PBXBuildFile; fileRef = 34B01148290015A60043951A /* Model */; };
+		3A08879C29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */; };
+		3A08879D29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */; };
 		3AA4D41F28FEBADE006C718A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D41E28FEBADE006C718A /* AppDelegate.swift */; };
 		3AA4D42128FEBADE006C718A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D42028FEBADE006C718A /* SceneDelegate.swift */; };
 		3AA4D42328FEBADE006C718A /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D42228FEBADE006C718A /* MainViewController.swift */; };
@@ -42,6 +44,8 @@
 		34B01142290015950043951A /* Extension */ = {isa = PBXFileReference; lastKnownFileType = text; path = Extension; sourceTree = "<group>"; };
 		34B011452900159F0043951A /* Resource */ = {isa = PBXFileReference; lastKnownFileType = text; path = Resource; sourceTree = "<group>"; };
 		34B01148290015A60043951A /* Model */ = {isa = PBXFileReference; lastKnownFileType = text; path = Model; sourceTree = "<group>"; };
+		3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoInformation+CoreDataClass.swift"; sourceTree = "<group>"; };
+		3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoInformation+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		3AA4D41B28FEBADE006C718A /* OrrRock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OrrRock.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AA4D41E28FEBADE006C718A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3AA4D42028FEBADE006C718A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -124,9 +128,19 @@
 		34B01147290015A10043951A /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				3A08879E29012CC300EFFDBB /* CoreData */,
 				34B01148290015A60043951A /* Model */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		3A08879E29012CC300EFFDBB /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */,
+				3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */,
+			);
+			path = CoreData;
 			sourceTree = "<group>";
 		};
 		3AA4D41228FEBADE006C718A = {
@@ -261,8 +275,10 @@
 				342508A729001BBC000653D9 /* HomeCollectionViewCardCell.swift in Sources */,
 				3AA4D42328FEBADE006C718A /* MainViewController.swift in Sources */,
 				3AA4D42328FEBADE006C718A /* MainViewController.swift in Sources */,
+				3A08879C29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift in Sources */,
 				707B2CB028FFFDB30062C958 /* UploadTestViewController.swift in Sources */,
 				3AA4D41F28FEBADE006C718A /* AppDelegate.swift in Sources */,
+				3A08879D29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift in Sources */,
 				342508A929001C2E000653D9 /* HomeCollectionViewCardCell+CollectionViewExtensions.swift in Sources */,
 				3AA4D42928FEBADE006C718A /* OrrRock.xcdatamodeld in Sources */,
 				342508A329001780000653D9 /* HomeViewController.swift in Sources */,

--- a/OrrRock/OrrRock/Models/CoreData/VideoInformation+CoreDataClass.swift
+++ b/OrrRock/OrrRock/Models/CoreData/VideoInformation+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  VideoInformation+CoreDataClass.swift
+//  OrrRock
+//
+//  Created by 황정현 on 2022/10/20.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(VideoInformation)
+public class VideoInformation: NSManagedObject {
+
+}

--- a/OrrRock/OrrRock/Models/CoreData/VideoInformation+CoreDataProperties.swift
+++ b/OrrRock/OrrRock/Models/CoreData/VideoInformation+CoreDataProperties.swift
@@ -1,0 +1,32 @@
+//
+//  VideoInformation+CoreDataProperties.swift
+//  OrrRock
+//
+//  Created by 황정현 on 2022/10/20.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension VideoInformation {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<VideoInformation> {
+        return NSFetchRequest<VideoInformation>(entityName: "VideoInformation")
+    }
+
+    @NSManaged public var feedback: String?
+    @NSManaged public var gymName: String
+    @NSManaged public var gymVisitDate: Date
+    @NSManaged public var id: UUID?
+    @NSManaged public var isFavorite: Bool
+    @NSManaged public var isSucceeded: Bool
+    @NSManaged public var problemLevel: Int16
+    @NSManaged public var videoUrl: String
+
+}
+
+extension VideoInformation : Identifiable {
+
+}

--- a/OrrRock/OrrRock/OrrRock.xcdatamodeld/OrrRock.xcdatamodel/contents
+++ b/OrrRock/OrrRock/OrrRock.xcdatamodeld/OrrRock.xcdatamodel/contents
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="true" userDefinedModelVersionIdentifier="">
-    <elements/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="VideoInformation" representedClassName="VideoInformation" syncable="YES" codeGenerationType="class">
+        <attribute name="feedback" optional="YES" attributeType="String"/>
+        <attribute name="gymName" attributeType="String" defaultValueString=""/>
+        <attribute name="gymVisitDate" attributeType="Date" defaultDateTimeInterval="687941220" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isSucceeded" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="problemLevel" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="videoUrl" attributeType="String" defaultValueString=""/>
+    </entity>
 </model>

--- a/OrrRock/OrrRock/OrrRock.xcdatamodeld/OrrRock.xcdatamodel/contents
+++ b/OrrRock/OrrRock/OrrRock.xcdatamodeld/OrrRock.xcdatamodel/contents
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
-    <entity name="VideoInformation" representedClassName="VideoInformation" syncable="YES" codeGenerationType="class">
+    <entity name="VideoInformation" representedClassName="VideoInformation" syncable="YES">
         <attribute name="feedback" optional="YES" attributeType="String"/>
         <attribute name="gymName" attributeType="String" defaultValueString=""/>
         <attribute name="gymVisitDate" attributeType="Date" defaultDateTimeInterval="687941220" usesScalarValueType="NO"/>


### PR DESCRIPTION
### 작업 내용 설명
1. 영상 정보 Data Model, VideoInformation 구조 작성
2. 프로젝트 파일에 Core Data Model 추가

|기본 데이터 구조 정보|
|:---:|
|<img width="700" alt="스크린샷 2022-10-20 오후 4 30 11" src="https://user-images.githubusercontent.com/96641477/196884529-a80c7fe1-a87e-435c-a5e3-3d00595a34a5.png">|

### 관련 이슈
- #9 

### 작업의 결과물

|Core Data Model|
|:---:|
|<img width="534" alt="스크린샷 2022-10-20 오후 4 31 30" src="https://user-images.githubusercontent.com/96641477/196884786-55fcaefc-abe5-4fe4-8cc3-6ae781a012e4.png">|

- Level이 20 이상보다 높을 가능성은 없다고 생각하여 `problemLevel`은 `Int16(범위값:  -32768 to 32767)`으로 지정했습니다.
-> 추후 기본 Int 자료형에서 형변환이 번거롭다고 판단될 경우, 변경될 여지가 존재합니다.

|파일 추가|
|:---:|
|<img width="265" alt="스크린샷 2022-10-20 오후 4 27 52" src="https://user-images.githubusercontent.com/96641477/196883980-3aa7a1de-2f40-4d0f-b841-d904c5cf3c7c.png">|

- extension 추후 Date Format 변환과 관련하여 Model의 추가 메소드 구현이 필요할 것이라고 판단하여, Codegen을 ```ClassDefinition```에서 ```Manual/None```으로 변경했습니다.

|폴더링|
|:---:|
|<img width="269" alt="스크린샷 2022-10-20 오후 4 35 00" src="https://user-images.githubusercontent.com/96641477/196885495-ec09160a-5e13-421b-9b36-6dfc2afc7a82.png">|
- 추후 CoreDataManager 등의 Data Model 관련 클래스의 위치 또한 Core Data 하위로 편입될 가능성이 존재합니다.

### 작업의 비고사항 및 한계점
- Merge 후 CoreData의 CRUD를 담당하는 CoreDataManager 클래스를 작성할 예정입니다.

### To Reviewers
**Q. Models -> Core Data -> Core Data 관련 Extension 파일이 있는 구조가 괜찮을까요?**
- `Data Model의 Extrension이긴 하지만, Model 그 자체`인 두 파일들의 위치를 어디로 지정하면 좋을까요?

Close #9