### PR TITLE
[#17] feat -  HomeVeiwController에 기존 로직 추가

### DIFF
--- a/OrrRock/OrrRock/SceneDelegate.swift
+++ b/OrrRock/OrrRock/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         window?.backgroundColor = .systemBackground
 
-        window?.rootViewController = UINavigationController(rootViewController: MainViewController())
+        window?.rootViewController = UINavigationController(rootViewController: HomeViewController())
 //        업로드 이후 동작이 필요하다면 위의 코드를 주석 아래코드를 주석 해제후 사용해주세요.
 //        window?.rootViewController = UINavigationController(rootViewController: UploadTestViewController())
 //        window?.rootViewController = UINavigationController(rootViewController: HomeViewController())

--- a/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController.swift
+++ b/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController.swift
@@ -234,7 +234,7 @@ extension HomeViewController: PHPickerViewControllerDelegate {
             results[i].itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { url, err in
                 if url != nil {
                     myArray.append(url!)
-                    if results.count == myArray.count{
+                    if results.count == myArray.count {
                         DispatchQueue.main.sync {
                             //인디케이터 종료
                             self.stopIndicator()

--- a/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController.swift
+++ b/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController.swift
@@ -77,7 +77,7 @@ final class HomeViewController : UIViewController {
         var items: [UIBarButtonItem] = []
         
         let myPageButton = UIBarButtonItem(image: UIImage(systemName: "person.crop.rectangle"), style: .plain, target: self, action: nil)
-        let addVideoButton = UIBarButtonItem(image: UIImage(systemName: "camera.fill"), style: .plain, target: self, action: #selector(testButtonPressed))
+        let addVideoButton = UIBarButtonItem(image: UIImage(systemName: "camera.fill"), style: .plain, target: self, action: #selector(videoButtonPressed))
 
         // toolbar 내 Spacer() 역할
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: HomeViewController.self, action: nil)
@@ -191,7 +191,7 @@ final class HomeViewController : UIViewController {
 
 extension HomeViewController {
 
-    @objc func testButtonPressed(sender: UIButton!) {
+    @objc func videoButtonPressed(sender: UIButton!) {
         var configuration = PHPickerConfiguration()
         configuration.selectionLimit = 0
         //인디게이터 도는거 보고 싶으면 아랫줄을 주석 처리해주세요.
@@ -218,7 +218,8 @@ extension HomeViewController: PHPickerViewControllerDelegate {
 
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true)
-        var myArray: [URL] = []
+        var videoUrlArray: [URL] = []
+        var errorCount = 0
         //인디케이트를 소환합니다.
         startIndicator()
 
@@ -231,14 +232,17 @@ extension HomeViewController: PHPickerViewControllerDelegate {
         //선택된 영상에서 URL을 뽑아내는 로직입니다.
         for i in 0..<results.count {
             results[i].itemProvider.loadFileRepresentation(forTypeIdentifier: UTType.movie.identifier) { url, err in
-                if url != nil {
-                    myArray.append(url!)
-                    if results.count == myArray.count {
+                if url == nil {
+                    NSLog("Orr_HomeViewController_Err1:\(String(describing: err))\n")
+                    errorCount += 1
+                } else {
+                    videoUrlArray.append(url!)
+                    if results.count == videoUrlArray.count + errorCount {
                         DispatchQueue.main.sync {
                             //인디케이터 종료
                             self.stopIndicator()
                             let nextVC = UpoadTestNextViewController()
-                            nextVC.viewUrlArray = myArray
+                            nextVC.viewUrlArray = videoUrlArray
                             self.navigationController?.pushViewController(nextVC, animated: true)
                         }
                     }

--- a/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController.swift
+++ b/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController.swift
@@ -170,11 +170,10 @@ final class HomeViewController : UIViewController {
         indicator.snp.makeConstraints {
             $0.center.equalTo(self.view)
         }
-        
     }
 
     //이친구는 반복적으로 추가되고 삭제 되어야해서 따로 만들었습니다.
-    func addBlockTouchView(){
+    func addBlockTouchView() {
         self.view.addSubview(blockTouchView)
         blockTouchView.snp.makeConstraints {
             $0.top.equalTo(view.snp.top)
@@ -190,7 +189,7 @@ final class HomeViewController : UIViewController {
     }
 }
 
-extension HomeViewController{
+extension HomeViewController {
 
     @objc func testButtonPressed(sender: UIButton!) {
         var configuration = PHPickerConfiguration()
@@ -204,12 +203,12 @@ extension HomeViewController{
     }
 
     //터치를 제한하는 뷰를 추가하고 인디게이터를 실행 시킵니다.
-    func startIndicator(){
+    func startIndicator() {
         addBlockTouchView()
         indicator.startAnimating()
     }
 
-    func stopIndicator(){
+    func stopIndicator() {
         self.indicator.stopAnimating()
         blockTouchView.removeFromSuperview()
     }
@@ -224,7 +223,7 @@ extension HomeViewController: PHPickerViewControllerDelegate {
         startIndicator()
 
         //사용자가 영상을 선택 하지 않은 상태일 때
-        if results.count == 0{
+        if results.count == 0 {
             //인디게이터 종료
             stopIndicator()
         }


### PR DESCRIPTION
### 작업 내용 설명
1. HomeViewController에 제가 기존에 만든 로직을 추가했습니다.

### 관련 이슈
- #17

### 작업의 결과물
- 제 기기에서 동작하는 영상은 개인 정보 문제로 시뮬레이터로 대체 합니다.
https://user-images.githubusercontent.com/103024840/197003018-078d8e9f-91fc-4d3c-8858-80d2999c5676.mov


### 작업의 비고사항 및 한계점
- 화이트 스페이싱등 코드를 정렬하고 싶었으나
- 해당 뷰를 레드도 작업하고 있어 최대한 수정하지 않았습니다.

### NSLog VS print
이번에 작성한 코드에 NSLog를 사용하게 되서 간단하게 설명해보겠습니다.
영상을 가져오는 과정에서 에러를 NSLog로 찍고 있는데 이유는 다음과 같습니다.
<img width="1054" alt="스크린샷 2022-10-21 오후 6 27 22" src="https://user-images.githubusercontent.com/103024840/197162898-1fae7e7b-ee98-45e3-87eb-3b51285a09d4.png">

비교를 위해 정상동작 print와 NSLog를 같이 출력해볼게요.
<img width="1110" alt="스크린샷 2022-10-21 오후 5 01 01" src="https://user-images.githubusercontent.com/103024840/197163378-11c7785e-aed1-4240-8086-6b8da99c6fed.png">

Xcode에서 확인해보면
날자값이 추가된것이 NSLog입니다.
<img width="1110" alt="스크린샷 2022-10-21 오후 5 01 19" src="https://user-images.githubusercontent.com/103024840/197163331-011a74c4-a6a6-46a4-9f15-b0a6a28d972a.png">

이렇게만 보면 별 차이가 없는데 왜 NSLog를 사용할까요?
단순히 날짜만 보려고 사용 하는것은 아닙니다.
아래보이는 화면은 아이폰에서 찍히는 모든 로그를 볼 수 있는 창입니다.
<img width="656" alt="스크린샷 2022-10-21 오후 5 02 37" src="https://user-images.githubusercontent.com/103024840/197163596-392653f4-f603-4188-bdde-e26112a8b23a.png">
내용을 보면 TestLog는 보이나 TestPrint는 보이지 않습니다.
네 print는 저기에 출력되지 않아요.

추가적으로 사용자 혹은 특정 아이폰에서 테스트를 하다가 오류가 발견되었을 때 콘솔에 연결해서 관제하면 바로 오류 로그를 볼 수있습니다.

제가 여기서 사용한 것은 제가 작성한 코드가 에러 상황을 발생시키지 못하였지만 
일단 예외처리는 필요하다는 리뷰를 받아 예외처리를 했고 해당 이슈 발생시 
사용자의 폰을 사용해 어떤 오류인지 바로 확인하려고 추가했습니다.!!

Close #17 

