### PR TITLE
[#14] feat - CoreDataManager 구현: CREAT

### DIFF
--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		34B01149290015A60043951A /* Model in Resources */ = {isa = PBXBuildFile; fileRef = 34B01148290015A60043951A /* Model */; };
 		3A08879C29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */; };
 		3A08879D29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */; };
+		3A70C3C62901435200BE11B5 /* VideoInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A70C3C52901435200BE11B5 /* VideoInfo.swift */; };
 		3AA4D41F28FEBADE006C718A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D41E28FEBADE006C718A /* AppDelegate.swift */; };
 		3AA4D42128FEBADE006C718A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D42028FEBADE006C718A /* SceneDelegate.swift */; };
 		3AA4D42328FEBADE006C718A /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D42228FEBADE006C718A /* MainViewController.swift */; };
@@ -46,6 +47,7 @@
 		34B01148290015A60043951A /* Model */ = {isa = PBXFileReference; lastKnownFileType = text; path = Model; sourceTree = "<group>"; };
 		3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoInformation+CoreDataClass.swift"; sourceTree = "<group>"; };
 		3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoInformation+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		3A70C3C52901435200BE11B5 /* VideoInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoInfo.swift; sourceTree = "<group>"; };
 		3AA4D41B28FEBADE006C718A /* OrrRock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OrrRock.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AA4D41E28FEBADE006C718A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3AA4D42028FEBADE006C718A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -139,6 +141,7 @@
 			children = (
 				3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */,
 				3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */,
+				3A70C3C52901435200BE11B5 /* VideoInfo.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				342508A329001780000653D9 /* HomeViewController.swift in Sources */,
 				342508A52900196B000653D9 /* HomeViewController+CollectionViewExtensions.swift in Sources */,
 				3AA4D42128FEBADE006C718A /* SceneDelegate.swift in Sources */,
+				3A70C3C62901435200BE11B5 /* VideoInfo.swift in Sources */,
 				342508AB29001CF8000653D9 /* HomeCardCollectionViewThumbnailCell.swift in Sources */,
 				707B2CB528FFFEFF0062C958 /* UpoadTestNextViewController.swift in Sources */,
 			);

--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		3A08879C29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */; };
 		3A08879D29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */; };
 		3A70C3C62901435200BE11B5 /* VideoInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A70C3C52901435200BE11B5 /* VideoInfo.swift */; };
+		3A70C3CF2901CB9600BE11B5 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A70C3CE2901CB9600BE11B5 /* CoreDataManager.swift */; };
 		3AA4D41F28FEBADE006C718A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D41E28FEBADE006C718A /* AppDelegate.swift */; };
 		3AA4D42128FEBADE006C718A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D42028FEBADE006C718A /* SceneDelegate.swift */; };
 		3AA4D42328FEBADE006C718A /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4D42228FEBADE006C718A /* MainViewController.swift */; };
@@ -48,6 +49,7 @@
 		3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoInformation+CoreDataClass.swift"; sourceTree = "<group>"; };
 		3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoInformation+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		3A70C3C52901435200BE11B5 /* VideoInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoInfo.swift; sourceTree = "<group>"; };
+		3A70C3CE2901CB9600BE11B5 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		3AA4D41B28FEBADE006C718A /* OrrRock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OrrRock.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AA4D41E28FEBADE006C718A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3AA4D42028FEBADE006C718A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 				3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */,
 				3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */,
 				3A70C3C52901435200BE11B5 /* VideoInfo.swift */,
+				3A70C3CE2901CB9600BE11B5 /* CoreDataManager.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -278,6 +281,7 @@
 				342508A729001BBC000653D9 /* HomeCollectionViewCardCell.swift in Sources */,
 				3AA4D42328FEBADE006C718A /* MainViewController.swift in Sources */,
 				3AA4D42328FEBADE006C718A /* MainViewController.swift in Sources */,
+				3A70C3CF2901CB9600BE11B5 /* CoreDataManager.swift in Sources */,
 				3A08879C29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift in Sources */,
 				707B2CB028FFFDB30062C958 /* UploadTestViewController.swift in Sources */,
 				3AA4D41F28FEBADE006C718A /* AppDelegate.swift in Sources */,

--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -143,8 +143,8 @@
 			children = (
 				3A08879A29012C8A00EFFDBB /* VideoInformation+CoreDataClass.swift */,
 				3A08879B29012C8A00EFFDBB /* VideoInformation+CoreDataProperties.swift */,
-				3A70C3C52901435200BE11B5 /* VideoInfo.swift */,
 				3A70C3CE2901CB9600BE11B5 /* CoreDataManager.swift */,
+				3A70C3C52901435200BE11B5 /* VideoInfo.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";

--- a/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
+++ b/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
@@ -1,0 +1,17 @@
+//
+//  CoreDataManager.swift
+//  OrrRock
+//
+//  Created by 황정현 on 2022/10/21.
+//
+
+import UIKit
+import CoreData
+
+class CoreDataManager {
+    
+    static var shared = CoreDataManager()
+    
+    private let appDelegate = UIApplication.shared.delegate as! AppDelegate
+    private lazy var context = appDelegate.persistentContainer.viewContext
+}

--- a/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
+++ b/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
@@ -28,11 +28,11 @@ class CoreDataManager {
         entity.setValue(info.feedback, forKey: "feedback")
         entity.setValue(info.isFavorite, forKey: "isFavorite")
         
-        saveData(context: context)
+        saveData()
     }
     
     // 추가한 데이터를 현재 context에 반영
-    func saveData(context: NSManagedObjectContext) {
+    func saveData() {
         do {
             try context.save()
         } catch {

--- a/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
+++ b/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
@@ -14,4 +14,13 @@ class CoreDataManager {
     
     private let appDelegate = UIApplication.shared.delegate as! AppDelegate
     private lazy var context = appDelegate.persistentContainer.viewContext
+    
+    // 추가한 데이터를 현재 context에 반영
+    func saveData(context: NSManagedObjectContext) {
+        do {
+            try context.save()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
 }

--- a/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
+++ b/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
@@ -25,8 +25,6 @@ class CoreDataManager {
         entity.setValue(info.videoUrl, forKey: "videoUrl")
         entity.setValue(info.problemLevel, forKey: "problemLevel")
         entity.setValue(info.isSucceeded, forKey: "isSucceeded")
-        entity.setValue(info.feedback, forKey: "feedback")
-        entity.setValue(info.isFavorite, forKey: "isFavorite")
         
         saveData()
     }

--- a/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
+++ b/OrrRock/OrrRock/Models/CoreData/CoreDataManager.swift
@@ -15,6 +15,22 @@ class CoreDataManager {
     private let appDelegate = UIApplication.shared.delegate as! AppDelegate
     private lazy var context = appDelegate.persistentContainer.viewContext
     
+    // VideoInfo 구조체를 매개변수로 받아 VideoInformation NSManagedObject에 추가
+    func createData(info: VideoInfo) {
+        let entity = NSEntityDescription.insertNewObject(forEntityName: "VideoInformation", into: context)
+        
+        entity.setValue(UUID(), forKey: "id")
+        entity.setValue(info.gymName, forKey: "gymName")
+        entity.setValue(info.gymVisitDate, forKey: "gymVisitDate")
+        entity.setValue(info.videoUrl, forKey: "videoUrl")
+        entity.setValue(info.problemLevel, forKey: "problemLevel")
+        entity.setValue(info.isSucceeded, forKey: "isSucceeded")
+        entity.setValue(info.feedback, forKey: "feedback")
+        entity.setValue(info.isFavorite, forKey: "isFavorite")
+        
+        saveData(context: context)
+    }
+    
     // 추가한 데이터를 현재 context에 반영
     func saveData(context: NSManagedObjectContext) {
         do {

--- a/OrrRock/OrrRock/Models/CoreData/VideoInfo.swift
+++ b/OrrRock/OrrRock/Models/CoreData/VideoInfo.swift
@@ -13,17 +13,12 @@ struct VideoInfo {
     var videoUrl: String
     var problemLevel: Int
     var isSucceeded: Bool
-    var feedback: String
-    var isFavorite: Bool
     
-    // 기본 Initializer: isFavorite, feedback은 자동적으로 할당
     init(gymName: String, gymVisitDate: Date, videoUrl: String, problemLevel: Int, isSucceeded: Bool) {
         self.gymName = gymName
         self.gymVisitDate = gymVisitDate
         self.videoUrl = videoUrl
         self.problemLevel = problemLevel
         self.isSucceeded = isSucceeded
-        self.isFavorite = false
-        self.feedback = ""
     }
 }

--- a/OrrRock/OrrRock/Models/CoreData/VideoInfo.swift
+++ b/OrrRock/OrrRock/Models/CoreData/VideoInfo.swift
@@ -1,0 +1,29 @@
+//
+//  VideoInfo.swift
+//  OrrRock
+//
+//  Created by 황정현 on 2022/10/20.
+//
+
+import Foundation
+
+struct VideoInfo {
+    var gymName: String
+    var gymVisitDate: Date
+    var videoUrl: String
+    var problemLevel: Int
+    var isSucceeded: Bool
+    var feedback: String
+    var isFavorite: Bool
+    
+    // 기본 Initializer: isFavorite, feedback은 자동적으로 할당
+    init(gymName: String, gymVisitDate: Date, videoUrl: String, problemLevel: Int, isSucceeded: Bool) {
+        self.gymName = gymName
+        self.gymVisitDate = gymVisitDate
+        self.videoUrl = videoUrl
+        self.problemLevel = problemLevel
+        self.isSucceeded = isSucceeded
+        self.isFavorite = false
+        self.feedback = ""
+    }
+}


### PR DESCRIPTION
### 작업 내용 설명
1. CoreData Entity의 편리한 추가를 위한 Struct `VideoInfo` 작성
2. CoreDataManager 기본 싱글톤 클래스 작성
3. CoreData Entity 생성 메소드 만들기

### 관련 이슈
- #14 

### 작업의 결과물
- CoreData Entity의 편리한 추가를 위한 Struct의 구조는 **VideoInfo.swift**에서 확인가능합니다.
- VideoInfo 구조체의 경우, 데이터 만들어서 추가하는 경우에만 사용되는 모델로 작성했기 때문에 현재 Initializer는 구조체의 모든 Property를 직접 할당하지는 않습니다.
- 직접 할당하지 않는 데이터: isFavorite(즐겨찾기 항목), feedback(문제에 대한 피드백)

- Core Data 데이터 추가를 위한 메소드 ```func createData(info: VideoInfo)```와 추가된 데이터를 context 반영하기 위한 메소드 ```func saveData()```는 **CoreDataManager.swift**에서 확인가능합니다.

- 작업의 결과물이 따로 존재하지 않는 경우에는 기록 X

### 작업의 비고사항 및 한계점
- 데이터 생성 메소드만으로는 테스트할 수 있는 예시가 존재하지 않기 때문에 추후 #15 구현 후 테스트가 가능합니다.

### To Reviewers
Q. VideoInfo 구조체의 추가적인 Initializer가 필요할까요? 현재 데이터 모델에서 사용될 것이라고 추측되는 Initializer는 이번 Issue에서 작성한 해당 init이지만, 여러 케이스를 고려해 전체 프로퍼티를 직접 할당하는 Initializer도 작성하면 좋을지에 대해 팀원분들의 의견이 궁금합니다!

### Thanks to
- Core Data 관련 질문을 받아주신 **코인** @Juhwa-Lee1023 , **꼬마** @hminkim 감사합니다!

Close #14 
