### PR TITLE
[#22] fix - 컬러명을 수정 

### DIFF
--- a/OrrRock/OrrRock/Assets.xcassets/Colors/oRGray2.colorset/Contents.json
+++ b/OrrRock/OrrRock/Assets.xcassets/Colors/oRGray2.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x55",
-          "green" : "0x55",
-          "red" : "0x55"
+          "blue" : "0xE1",
+          "green" : "0xE1",
+          "red" : "0xE1"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x55",
-          "green" : "0x55",
-          "red" : "0x55"
+          "blue" : "0xE1",
+          "green" : "0xE1",
+          "red" : "0xE1"
         }
       },
       "idiom" : "universal"

--- a/OrrRock/OrrRock/Assets.xcassets/Colors/oRGray3.colorset/Contents.json
+++ b/OrrRock/OrrRock/Assets.xcassets/Colors/oRGray3.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE1",
-          "green" : "0xE1",
-          "red" : "0xE1"
+          "blue" : "0x96",
+          "green" : "0x96",
+          "red" : "0x96"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xE1",
-          "green" : "0xE1",
-          "red" : "0xE1"
+          "blue" : "0x96",
+          "green" : "0x96",
+          "red" : "0x96"
         }
       },
       "idiom" : "universal"

--- a/OrrRock/OrrRock/Assets.xcassets/Colors/oRGray4.colorset/Contents.json
+++ b/OrrRock/OrrRock/Assets.xcassets/Colors/oRGray4.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0x55",
+          "green" : "0x55",
+          "red" : "0x55"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x96",
-          "green" : "0x96",
-          "red" : "0x96"
+          "blue" : "0x55",
+          "green" : "0x55",
+          "red" : "0x55"
         }
       },
       "idiom" : "universal"

--- a/OrrRock/OrrRock/Extensions/Color+.swift
+++ b/OrrRock/OrrRock/Extensions/Color+.swift
@@ -15,9 +15,9 @@ extension UIColor{
     static let orrBlack = UIColor(named: "oRBlack")
     static let orrWhite = UIColor(named: "oRWhite")
     static let orrGray1 = UIColor(named: "oRGray1")
-    static let orrGray3 = UIColor(named: "oRGray3")
-    static let orrGray4 = UIColor(named: "oRGray4")
-    static let orrGray5 = UIColor(named: "oRGray5")
+    static let orrGray3 = UIColor(named: "oRGray2")
+    static let orrGray4 = UIColor(named: "oRGray3")
+    static let orrGray5 = UIColor(named: "oRGray4")
 
     //SUB COLOR
     static let orrPass = UIColor(named: "oRPass")

--- a/OrrRock/OrrRock/Extensions/Color+.swift
+++ b/OrrRock/OrrRock/Extensions/Color+.swift
@@ -15,9 +15,9 @@ extension UIColor{
     static let orrBlack = UIColor(named: "oRBlack")
     static let orrWhite = UIColor(named: "oRWhite")
     static let orrGray1 = UIColor(named: "oRGray1")
-    static let orrGray3 = UIColor(named: "oRGray2")
-    static let orrGray4 = UIColor(named: "oRGray3")
-    static let orrGray5 = UIColor(named: "oRGray4")
+    static let orrGray2 = UIColor(named: "oRGray2")
+    static let orrGray3 = UIColor(named: "oRGray3")
+    static let orrGray4 = UIColor(named: "oRGray4")
 
     //SUB COLOR
     static let orrPass = UIColor(named: "oRPass")


### PR DESCRIPTION
### 작업 내용 설명
1. 컬러명 수정

### 관련 이슈
- #22

### 작업의 결과물
- orrGray2 가 추가 되었습니다.
- 추후 다크모드 생성시 제가 추가한 모든 색상에 라이트 다크 모드 구분 하여 색상 추가 가능합니다.
<img width="378" alt="스크린샷 2022-10-21 오후 3 30 40" src="https://user-images.githubusercontent.com/103024840/197128235-264bc27d-a413-4783-84f9-700cf57ca70e.png">

### 작업의 비고사항 및 한계점
- 비고사항 및 한계점이 없다면 기록 X


Close #22
