### PR TITLE
[#101] fix - 피드백 글자와 날짜 정보 겹쳐짐

### DIFF
--- a/OrrRock/OrrRock/Views/VideoDetailView/VideoInfoView.swift
+++ b/OrrRock/OrrRock/Views/VideoDetailView/VideoInfoView.swift
@@ -161,7 +161,7 @@ extension VideoInfoView {
         // textView
         self.addSubview(feedbackTextView)
         feedbackTextView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(orrPadding.padding3.rawValue)
             $0.top.equalTo(self.snp.top).offset(orrPadding.padding3.rawValue)
             $0.height.equalTo(120)
         }
@@ -169,14 +169,14 @@ extension VideoInfoView {
         self.addSubview(dateView)
         dateView.snp.makeConstraints {
             $0.height.equalTo(80)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(orrPadding.padding3.rawValue)
             $0.top.equalTo(feedbackTextView.snp.bottom)
         }
         // 문제 난이도 뷰
         self.addSubview(levelView)
         levelView.snp.makeConstraints {
             $0.height.equalTo(80)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.leading.trailing.equalToSuperview().inset(orrPadding.padding3.rawValue)
             $0.top.equalTo(dateView.snp.bottom).offset(orrPadding.padding3.rawValue)
         }
         // 날짜 레이블

--- a/OrrRock/OrrRock/Views/VideoDetailView/VideoInfoView.swift
+++ b/OrrRock/OrrRock/Views/VideoDetailView/VideoInfoView.swift
@@ -163,14 +163,14 @@ extension VideoInfoView {
         feedbackTextView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(orrPadding.padding3.rawValue)
             $0.top.equalTo(self.snp.top).offset(orrPadding.padding3.rawValue)
-            $0.height.equalTo(120)
+            $0.height.equalTo(110)
         }
         // 날짜 입력 뷰
         self.addSubview(dateView)
         dateView.snp.makeConstraints {
             $0.height.equalTo(80)
             $0.leading.trailing.equalToSuperview().inset(orrPadding.padding3.rawValue)
-            $0.top.equalTo(feedbackTextView.snp.bottom)
+			$0.top.equalTo(feedbackTextView.snp.bottom).offset(orrPadding.padding3.rawValue)
         }
         // 문제 난이도 뷰
         self.addSubview(levelView)

--- a/OrrRock/OrrRock/Views/VideoDetailView/VideoInfoView.swift
+++ b/OrrRock/OrrRock/Views/VideoDetailView/VideoInfoView.swift
@@ -197,7 +197,7 @@ extension VideoInfoView {
             $0.top.equalTo(levelView.snp.top).offset(orrPadding.padding4.rawValue)
             $0.leading.equalTo(levelView.snp.leading).offset(orrPadding.padding4.rawValue)
         }
-        // 난이도 레이블
+        // 성공 여부 레이블
         levelView.addSubview(isSucceeded)
         isSucceeded.snp.makeConstraints {
             $0.bottom.equalTo(levelView.snp.bottom).inset(orrPadding.padding4.rawValue)


### PR DESCRIPTION
### 작업 내용 설명
1. 겹쳐지는 것 처럼 보이는 영상 텍스트 부분이랑 하단 버튼 사이에 패딩값을 주는 작업

### 관련 이슈
- #101 

### 작업의 결과물
<img src="https://user-images.githubusercontent.com/45965405/200174441-bf856dbe-1fb1-40c0-843a-eaa2fcd96c0e.jpeg"  width="300">

### To Reviewers
- 텍스트가 5줄 이상이 되었을 때 날짜, 암장을 보여주는 뷰와 겹치지 않게 패딩값을 준 부분 확인 부탁드립니다.

Close #101 
