### PR TITLE
[#102] fix 영상테두리추가

### DIFF
--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		70A44807290452B000BE18A5 /* Button+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A44806290452B000BE18A5 /* Button+.swift */; };
 		70A44809290464BD00BE18A5 /* GymSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A44808290464BD00BE18A5 /* GymSettingViewController.swift */; };
 		70A8DF05291403EA0061E36B /* GymSettingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A8DF04291403EA0061E36B /* GymSettingModel.swift */; };
+		70A8DF08291966E20061E36B /* SwipeableCardVideoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70A8DF07291966E20061E36B /* SwipeableCardVideoModel.swift */; };
 		78A0354C290131E100FF1913 /* VideoCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78A0354B290131E100FF1913 /* VideoCollectionViewController.swift */; };
 		78A03550290132D300FF1913 /* VideoCollectionViewCustomCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78A0354F290132D300FF1913 /* VideoCollectionViewCustomCell.swift */; };
 		78CAA0662901F7A9003C3D77 /* BasePaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78CAA0652901F7A9003C3D77 /* BasePaddingLabel.swift */; };
@@ -129,6 +130,7 @@
 		70A44806290452B000BE18A5 /* Button+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Button+.swift"; sourceTree = "<group>"; };
 		70A44808290464BD00BE18A5 /* GymSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymSettingViewController.swift; sourceTree = "<group>"; };
 		70A8DF04291403EA0061E36B /* GymSettingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymSettingModel.swift; sourceTree = "<group>"; };
+		70A8DF07291966E20061E36B /* SwipeableCardVideoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableCardVideoModel.swift; sourceTree = "<group>"; };
 		78A0354B290131E100FF1913 /* VideoCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCollectionViewController.swift; sourceTree = "<group>"; };
 		78A0354F290132D300FF1913 /* VideoCollectionViewCustomCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCollectionViewCustomCell.swift; sourceTree = "<group>"; };
 		78CAA0652901F7A9003C3D77 /* BasePaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePaddingLabel.swift; sourceTree = "<group>"; };
@@ -363,9 +365,18 @@
 		70A8DF03291403C10061E36B /* UploadModels */ = {
 			isa = PBXGroup;
 			children = (
+				70A8DF06291966900061E36B /* SwipeableCardModel */,
 				70A8DF04291403EA0061E36B /* GymSettingModel.swift */,
 			);
 			path = UploadModels;
+			sourceTree = "<group>";
+		};
+		70A8DF06291966900061E36B /* SwipeableCardModel */ = {
+			isa = PBXGroup;
+			children = (
+				70A8DF07291966E20061E36B /* SwipeableCardVideoModel.swift */,
+			);
+			path = SwipeableCardModel;
 			sourceTree = "<group>";
 		};
 		78A035492901317600FF1913 /* VideoCollectionView */ = {
@@ -511,6 +522,7 @@
 				70A44805290440E600BE18A5 /* DateSettingViewController.swift in Sources */,
 				342C457029018D5C0037D9E7 /* HomeCollectionViewFooterCell.swift in Sources */,
 				3A2880E929033C0D00FBFB70 /* SortOption.swift in Sources */,
+				70A8DF08291966E20061E36B /* SwipeableCardVideoModel.swift in Sources */,
 				342C456E290125260037D9E7 /* HomeCollectionViewListCell.swift in Sources */,
 				FB3227FC2903FD9C00276A7D /* Date+.swift in Sources */,
 				78F93ED32906EFC500F3D9F3 /* DateAndGymEditViewController.swift in Sources */,
@@ -698,7 +710,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = HD34Q2YK79;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -730,9 +742,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = HD34Q2YK79;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -750,6 +763,7 @@
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -709,7 +709,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -726,7 +725,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -746,7 +744,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
@@ -763,7 +760,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/OrrRock/OrrRock/Models/UploadModels/SwipeableCardModel/SwipeableCardVideoModel.swift
+++ b/OrrRock/OrrRock/Models/UploadModels/SwipeableCardModel/SwipeableCardVideoModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum VideoBackgroundViewBorderColor{
+enum VideoBackgroundViewBorderColor {
     case pass
     case fail
     case clear

--- a/OrrRock/OrrRock/Models/UploadModels/SwipeableCardModel/SwipeableCardVideoModel.swift
+++ b/OrrRock/OrrRock/Models/UploadModels/SwipeableCardModel/SwipeableCardVideoModel.swift
@@ -1,0 +1,14 @@
+//
+//  SwipeableCardVideoModel.swift
+//  OrrRock
+//
+//  Created by Ruyha on 2022/11/08.
+//
+
+import Foundation
+
+enum VideoBackgroundViewBorderColor{
+    case pass
+    case fail
+    case clear
+}

--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardVideoView.swift
@@ -116,12 +116,12 @@ private extension SwipeableCardVideoView {
 
 extension SwipeableCardVideoView {
     
-    func setVideoBackgroundViewBorderColor(color: VideoBackgroundViewBorderColor,alpha: CGFloat){
-        var r = 0.0
-        var g = 0.0
-        var b = 0.0
+    func setVideoBackgroundViewBorderColor(color: VideoBackgroundViewBorderColor,alpha: CGFloat) {
+        var r : CGFloat = 0.0
+        var g : CGFloat = 0.0
+        var b : CGFloat = 0.0
         
-        switch color{
+        switch color {
         case.pass :
             r = 48; g = 176; b = 199
         case .fail :

--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardVideoView.swift
@@ -14,11 +14,15 @@ import AVFoundation
 final class SwipeableCardVideoView: UIView {
 
     var video: VideoInfo?
-    
+    let cornerRadius: CGFloat = 10
+
     private lazy var videoBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .blue
-        
+        view.layer.borderWidth = 3
+        view.layer.cornerRadius = cornerRadius
+        view.layer.borderColor = UIColor.white.cgColor
+
         return view
     }()
 
@@ -58,6 +62,9 @@ final class SwipeableCardVideoView: UIView {
         super.layoutSubviews()
         
         self.playerLayer?.frame = self.videoBackgroundView.bounds
+        self.playerLayer?.masksToBounds = true
+        self.playerLayer?.cornerRadius = cornerRadius
+        
     }
 }
 
@@ -104,5 +111,25 @@ private extension SwipeableCardVideoView {
              $0.height.equalTo(30.0)
              $0.width.equalTo(100.0)
          }
+    }
+}
+
+extension SwipeableCardVideoView {
+    
+    func setVideoBackgroundViewBorderColor(color: VideoBackgroundViewBorderColor,alpha: CGFloat){
+        var r = 0.0
+        var g = 0.0
+        var b = 0.0
+        
+        switch color{
+        case.pass :
+            r = 48; g = 176; b = 199
+        case .fail :
+            r = 242; g = 52; b = 52
+        case .clear :
+            r = 255; g = 255; b = 255
+        }
+
+        videoBackgroundView.layer.borderColor = UIColor(red:r/255.0, green:g/255.0, blue:b/255.0, alpha: 1.0).cgColor
     }
 }

--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
@@ -328,9 +328,8 @@ private extension SwipeableCardViewController {
                     card.failImageView.alpha = isSuccess == false ? 1 : 0
                     if isSuccess{
                         card.setVideoBackgroundViewBorderColor(color: .pass, alpha: 1)
-                    }else{
+                    } else {
                         card.setVideoBackgroundViewBorderColor(color: .fail, alpha: 1)
-
                     }
                     
                 }) { [self] _ in

--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
@@ -244,9 +244,11 @@ private extension SwipeableCardViewController {
             if point.x > 0 {
                 card.successImageView.alpha = rotationAngle * 5
                 card.failImageView.alpha = 0
+                card.setVideoBackgroundViewBorderColor(color: .pass, alpha: rotationAngle * 5)
             } else {
                 card.successImageView.alpha = 0
                 card.failImageView.alpha = -rotationAngle * 5
+                card.setVideoBackgroundViewBorderColor(color: .fail, alpha: -rotationAngle * 5)
             }
             
             card.transform = CGAffineTransform(rotationAngle: rotationAngle)
@@ -267,6 +269,7 @@ private extension SwipeableCardViewController {
                     card.transform = .identity
                     card.successImageView.alpha = 0
                     card.failImageView.alpha = 0
+                    card.setVideoBackgroundViewBorderColor(color: .clear, alpha: 1)
                 }
             }
         }
@@ -323,6 +326,13 @@ private extension SwipeableCardViewController {
                     card.transform = CGAffineTransform(rotationAngle: rotationAngle)
                     card.successImageView.alpha = isSuccess == true ? 1 : 0
                     card.failImageView.alpha = isSuccess == false ? 1 : 0
+                    if isSuccess{
+                        card.setVideoBackgroundViewBorderColor(color: .pass, alpha: 1)
+                    }else{
+                        card.setVideoBackgroundViewBorderColor(color: .fail, alpha: 1)
+
+                    }
+                    
                 }) { [self] _ in
                     if counter != cards.count-1 {
                         print("DEBUG : \(counter) / \(cards.count - 1)")


### PR DESCRIPTION
### 작업 내용 설명
1. 영상 분류시 테두리가 추가되었습니다.
2. 상황에 따라 색상이 유동적으로 변경됩니다.

### 관련 이슈
- #102 

### 작업의 결과물
영상의 용량이커서 사진으로 대체 합니다.
|성공일때|중립일때(흰색)|실패일때|
|---|---|---|
|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/200361237-0b6cbd1a-9e6d-4801-a7c7-a9dae20ace5a.jpeg">|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/200361262-c22e256c-d562-443b-9691-7ebebe829407.jpeg">|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/200361268-64a0e5eb-9998-4860-afc7-18419a588a6c.jpeg">|


### 작업의 비고사항 및 한계점
- 생각보다 금방 끝나서 다행이에요.

### To Reviewers
- 사랑해요

Close #102
