### PR TITLE
[#106] fix - 영상 분류 완료 로직 개선

### DIFF
--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardVideoView.swift
@@ -44,6 +44,8 @@ final class SwipeableCardVideoView: UIView {
 
     private var player = AVPlayer()
     private var playerLayer: AVPlayerLayer?
+	private var queuePlayer = AVQueuePlayer()
+	private var playerLooper: AVPlayerLooper?
     private var asset: AVAsset
 
     init(asset: AVAsset) {
@@ -71,20 +73,16 @@ final class SwipeableCardVideoView: UIView {
 extension SwipeableCardVideoView {
     
     func embedVideo() {
-        let item = AVPlayerItem(asset: asset)
-        self.player.replaceCurrentItem(with: item)
-        
-        let playerLayer = AVPlayerLayer(player: self.player)
-        playerLayer.frame = self.videoBackgroundView.bounds
-        playerLayer.videoGravity = .resizeAspectFill
-        
-        self.playerLayer = playerLayer
-        self.videoBackgroundView.layer.addSublayer(playerLayer)
-//        self.player.play()
-    }
-    
-    func videoPlay() {
-        self.player.play()
+		let item = AVPlayerItem(asset: asset)
+		self.queuePlayer = AVQueuePlayer()
+		let playerLayer = AVPlayerLayer(player: self.queuePlayer)
+		playerLayer.frame = self.videoBackgroundView.bounds
+		playerLayer.videoGravity = .resizeAspectFill
+		self.playerLayer = playerLayer
+		self.videoBackgroundView.layer.addSublayer(playerLayer)
+		self.queuePlayer.isMuted = true
+		self.playerLooper = AVPlayerLooper(player: self.queuePlayer, templateItem: item)
+		self.queuePlayer.play()
     }
 }
 

--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
@@ -13,432 +13,426 @@ import SnapKit
 import Photos
 
 final class SwipeableCardViewController: UIViewController {
-    
-    var videoInfoArray: [VideoInfo] = []
-    
-    private lazy var titleLabel: UILabel = {
-        let label = UILabel()
-        label.text = "스와이프를 통해 비디오를 분류해주세요."
-        label.textColor = .orrBlack
-        label.font = .systemFont(ofSize: 17.0, weight: .semibold)
-        
-        return label
-    }()
-    
-    private lazy var levelButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("레벨", for: .normal)
-        button.setTitleColor(.orrGray3, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 17.0, weight: .semibold)
-        button.addTarget(self, action: #selector(pickLevel), for: .touchUpInside)
-        
-        return button
-    }()
-    
-    private lazy var levelButtonImage: UIImageView = {
-        let imageView = UIImageView()
-        imageView.image = UIImage(systemName: "chevron.down")
-        imageView.tintColor = .orrGray3
-        
-        return imageView
-    }()
-    
-    private lazy var buttonStackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.axis = .horizontal
-        stackView.alignment = .fill
-        stackView.distribution = .equalSpacing
-        stackView.spacing = 8
-        
-        return stackView
-    }()
-    
-    private lazy var separator: UIView = {
-        let separator = UIView()
-        separator.backgroundColor = .orrUPBlue
-        
-        return separator
-    }()
-    
-    private lazy var emptyVideoView: UIView = {
-        let view = UIView()
-        view.backgroundColor = .orrGray2
-        view.layer.cornerRadius = 10
-        view.clipsToBounds = true
-        
-        return view
-    }()
-    
-    private lazy var emptyVideoInformation: UILabel = {
-        let label = UILabel()
-        label.text = "모든 비디오를 분류했습니다!"
-        label.textColor = .orrGray3
-        label.font = .systemFont(ofSize: 15.0, weight: .regular)
-        
-        return label
-    }()
-    
-    private lazy var failButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("실패", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 16.0, weight: .semibold)
-        button.backgroundColor = .orrFail
-        button.layer.cornerRadius = 37.0
-        button.addTarget(self, action: #selector(didFailButton), for: .touchUpInside)
-        
-        return button
-    }()
-    
-    private lazy var successButton: UIButton = {
-        let button = UIButton()
-        button.setTitle("성공", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 16.0, weight: .semibold)
-        button.backgroundColor = .orrPass
-        button.layer.cornerRadius = 37.0
-        button.addTarget(self, action: #selector(didSuccessButton), for: .touchUpInside)
-        
-        return button
-    }()
-    
-    private lazy var saveButton : UIButton = {
-        let button = UIButton()
-        button.setBackgroundColor(.orrUPBlue!, for: .normal)
-        button.addTarget(self, action: #selector(tapSaveButton), for: .touchUpInside)
-        button.setTitle("저장하기", for: .normal)
-        button.clipsToBounds = true
-        button.layer.cornerRadius = 10.0
-        button.setTitleColor(.white, for: .normal)
-        button.isHidden = true
-        
-        return button
-    }()
-    
-    private var cards: [SwipeableCardVideoView?] = []
-    private var counter: Int = 0
-    private var currentSelectedLevel: Int?
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        view.backgroundColor = .white
-        
-        navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.left"), style: .plain, target: self, action: #selector(backButtonClicked))
-        navigationItem.leftBarButtonItem?.tintColor = .orrUPBlue
-        
-        // card UI
-        setUpLayout()
-        
-        createSwipeableCard() {
-            self.cards.forEach { swipeCard in
-                self.view.insertSubview(swipeCard!, at: 0)
-                swipeCard!.snp.makeConstraints {
-                    $0.center.equalToSuperview()
-                    $0.height.equalTo(420.0)
-                    $0.leading.trailing.equalToSuperview().inset(60.0)
-                }
-                
-                self.view.sendSubviewToBack(self.emptyVideoView)
-                
-                // gesture
-                let gesture = UIPanGestureRecognizer()
-                gesture.addTarget(self, action: #selector(self.handlerCard))
-                swipeCard!.addGestureRecognizer(gesture)
-            }
-            
-            CustomIndicator.stopLoading()
-        }
-    }
+	
+	var videoInfoArray: [VideoInfo] = []
+	
+	private lazy var titleLabel: UILabel = {
+		let label = UILabel()
+		label.text = "스와이프를 통해 비디오를 분류해주세요."
+		label.textColor = .orrBlack
+		label.font = .systemFont(ofSize: 17.0, weight: .semibold)
+		
+		return label
+	}()
+	
+	private lazy var levelButton: UIButton = {
+		let button = UIButton()
+		button.setTitle("레벨", for: .normal)
+		button.setTitleColor(.orrGray3, for: .normal)
+		button.titleLabel?.font = .systemFont(ofSize: 17.0, weight: .semibold)
+		button.addTarget(self, action: #selector(pickLevel), for: .touchUpInside)
+		
+		return button
+	}()
+	
+	private lazy var levelButtonImage: UIImageView = {
+		let imageView = UIImageView()
+		imageView.image = UIImage(systemName: "chevron.down")
+		imageView.tintColor = .orrGray3
+		
+		return imageView
+	}()
+	
+	private lazy var buttonStackView: UIStackView = {
+		let stackView = UIStackView()
+		stackView.axis = .horizontal
+		stackView.alignment = .fill
+		stackView.distribution = .equalSpacing
+		stackView.spacing = 8
+		
+		return stackView
+	}()
+	
+	private lazy var separator: UIView = {
+		let separator = UIView()
+		separator.backgroundColor = .orrUPBlue
+		
+		return separator
+	}()
+	
+	private lazy var emptyVideoView: UIView = {
+		let view = UIView()
+		view.backgroundColor = .orrGray2
+		view.layer.cornerRadius = 10
+		view.clipsToBounds = true
+		
+		return view
+	}()
+	
+	private lazy var emptyVideoInformation: UILabel = {
+		let label = UILabel()
+		label.text = "모든 비디오를 분류했습니다!"
+		label.textColor = .orrGray3
+		label.font = .systemFont(ofSize: 15.0, weight: .regular)
+		
+		return label
+	}()
+	
+	private lazy var failButton: UIButton = {
+		let button = UIButton()
+		button.setTitle("실패", for: .normal)
+		button.setTitleColor(.white, for: .normal)
+		button.titleLabel?.font = .systemFont(ofSize: 16.0, weight: .semibold)
+		button.backgroundColor = .orrFail
+		button.layer.cornerRadius = 37.0
+		button.addTarget(self, action: #selector(didFailButton), for: .touchUpInside)
+		
+		return button
+	}()
+	
+	private lazy var successButton: UIButton = {
+		let button = UIButton()
+		button.setTitle("성공", for: .normal)
+		button.setTitleColor(.white, for: .normal)
+		button.titleLabel?.font = .systemFont(ofSize: 16.0, weight: .semibold)
+		button.backgroundColor = .orrPass
+		button.layer.cornerRadius = 37.0
+		button.addTarget(self, action: #selector(didSuccessButton), for: .touchUpInside)
+		
+		return button
+	}()
+	
+	private lazy var saveButton : UIButton = {
+		let button = UIButton()
+		button.setBackgroundColor(.orrUPBlue!, for: .normal)
+		button.addTarget(self, action: #selector(tapSaveButton), for: .touchUpInside)
+		button.setTitle("저장하기", for: .normal)
+		button.clipsToBounds = true
+		button.layer.cornerRadius = 10.0
+		button.setTitleColor(.white, for: .normal)
+		button.isHidden = true
+		
+		return button
+	}()
+	
+	private var cards: [SwipeableCardVideoView?] = []
+	private var counter: Int = 0
+	private var currentSelectedLevel: Int?
+	
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		
+		view.backgroundColor = .white
+		
+		navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "chevron.left"), style: .plain, target: self, action: #selector(backButtonClicked))
+		navigationItem.leftBarButtonItem?.tintColor = .orrUPBlue
+		
+		// card UI
+		setUpLayout()
+		
+		createSwipeableCard() {
+			self.cards.forEach { swipeCard in
+				self.view.insertSubview(swipeCard!, at: 0)
+				swipeCard!.snp.makeConstraints {
+					$0.center.equalToSuperview()
+					$0.height.equalTo(420.0)
+					$0.leading.trailing.equalToSuperview().inset(60.0)
+				}
+				
+				self.view.sendSubviewToBack(self.emptyVideoView)
+				
+				// gesture
+				let gesture = UIPanGestureRecognizer()
+				gesture.addTarget(self, action: #selector(self.handlerCard))
+				swipeCard!.addGestureRecognizer(gesture)
+			}
+			
+			CustomIndicator.stopLoading()
+		}
+	}
 }
 
 extension SwipeableCardViewController: LevelPickerViewDelegate {
-    
-    func didLevelChanged(selectedLevel: Int) {
-        levelButton.setTitle("V\(selectedLevel)", for: .normal)
-        currentSelectedLevel = selectedLevel
-        
-        levelButton.setTitleColor(.black, for: .normal)
-        separator.backgroundColor = .black
-    }
+	
+	func didLevelChanged(selectedLevel: Int) {
+		levelButton.setTitle("V\(selectedLevel)", for: .normal)
+		currentSelectedLevel = selectedLevel
+		
+		levelButton.setTitleColor(.black, for: .normal)
+		separator.backgroundColor = .black
+	}
 }
 
 // Gesture
 private extension SwipeableCardViewController {
-    
-    // 목업용 카드를 만들어줍니다.
-    func createSwipeableCard(_ completion: @escaping () -> Void) {
-        
-        var identifiers: [String] = []
-        for videoInfo in videoInfoArray {
-            identifiers.append(videoInfo.videoLocalIdentifier)
-        }
-        
-        let option = PHFetchOptions()
-        option.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
-        
-        let assets = PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: option)
-        cards = Array(repeating: nil, count: assets.count)
-        var totalCount = cards.count
-        
-        CustomIndicator.startLoading()
-        
-        for index in 0..<assets.count {
-            guard (assets[index].mediaType == PHAssetMediaType.video)
-                    
-            else {
-                print("Not a valid video media type")
-                return
-            }
-            
-            DispatchQueue.global().async {
-                
-                var asset: AVURLAsset?
-                PHCachingImageManager().requestAVAsset(forVideo: assets[index], options: nil) { (assets, audioMix, info) in
-                    asset = assets as? AVURLAsset
-                    
-                    guard let url = asset?.url else {
-                        return
-                    }
-                    
-                    var swipeCard = SwipeableCardVideoView(asset: AVAsset(url: url))
-                    
-                    if index == 0 {
-                        swipeCard.embedVideo()
-                        swipeCard.videoPlay()
-                    }
-                    
-//                    self.cards.append(swipeCard)
-                    self.cards[index] = swipeCard
-                    
-                    swipeCard.tag = index
-                    print(swipeCard.tag)
-                    
-                    
-                    DispatchQueue.main.async {
-                        totalCount -= 1
-                        
-                        if totalCount == 0 {
-                            completion()
-                        }
-                    }
-                }
-            }
-        }
-    }
-    
-    // swipeCard가 SuperView에서 제거됩니다.
-    @objc func removeCard(card: UIView) {
-        card.removeFromSuperview()
-    }
-    
-    // Gesture
-    @objc func handlerCard(_ gesture: UIPanGestureRecognizer) {
-        if let card = gesture.view as? SwipeableCardVideoView {
-            let point = gesture.translation(in: view)
-            
-            card.center = CGPoint(x: view.center.x + point.x, y: view.center.y + point.y)
-            
-            let rotationAngle = point.x / view.bounds.width * 0.4
-            
-            if point.x > 0 {
-                card.successImageView.alpha = rotationAngle * 5
-                card.failImageView.alpha = 0
-                card.setVideoBackgroundViewBorderColor(color: .pass, alpha: rotationAngle * 5)
-            } else {
-                card.successImageView.alpha = 0
-                card.failImageView.alpha = -rotationAngle * 5
-                card.setVideoBackgroundViewBorderColor(color: .fail, alpha: -rotationAngle * 5)
-            }
-            
-            card.transform = CGAffineTransform(rotationAngle: rotationAngle)
-            
-            if gesture.state == .ended {
-                if card.center.x > self.view.bounds.width + 20 {
-                    animateCard(rotationAngle: rotationAngle, videoResultType: .success)
-                    return
-                }
-                
-                if card.center.x < -20 {
-                    animateCard(rotationAngle: rotationAngle, videoResultType: .fail)
-                    return
-                }
-                
-                UIView.animate(withDuration: 0.2) {
-                    card.center = self.view.center
-                    card.transform = .identity
-                    card.successImageView.alpha = 0
-                    card.failImageView.alpha = 0
-                    card.setVideoBackgroundViewBorderColor(color: .clear, alpha: 1)
-                }
-            }
-        }
-    }
-    
-    @objc func pickLevel() {
-        let nextViewController = LevelPickerView()
-        self.navigationController?.present(nextViewController, animated: true)
-        nextViewController.delegate = self
-    }
-    
-    @objc func didFailButton() {
-        animateCard(rotationAngle: -0.4, videoResultType: .fail)
-    }
-    
-    @objc func didSuccessButton() {
-        animateCard(rotationAngle: 0.4, videoResultType: .success)
-    }
-    
-    @objc func tapSaveButton() {
-        // TODO: - 다음 뷰로 넘어가는 로직
-        DataManager.shared.createMultipleData(infoList: videoInfoArray)
-        self.navigationController?.popToRootViewController(animated: true)
-    }
-    
-    // swipeCard의 애니매이션 효과를 담당합니다.
-    func animateCard(rotationAngle: CGFloat, videoResultType: VideoResultType) {
-        
-        print(view.subviews.count)
-        var cardViews = view.subviews.filter({ ($0 as? SwipeableCardVideoView) != nil })
-        print("DDD ", cardViews.count)
-        
-        for view in cardViews {
-            if view == cards[counter] {
-                let center: CGPoint
-                let isSuccess: Bool
-                let  card = view as! SwipeableCardVideoView
-                
-                switch videoResultType {
-                case .fail:
-                    center = CGPoint(x: card.center.x - view.bounds.width, y: card.center.y + 30)
-                    isSuccess = false
-                    
-                case .success:
-                    center = CGPoint(x: card.center.x + view.bounds.width, y: card.center.y + 30)
-                    isSuccess = true
-                }
-                
-                videoInfoArray[counter].isSucceeded = isSuccess
-                videoInfoArray[counter].problemLevel = currentSelectedLevel ?? 0
-                print(videoInfoArray[counter])
-                UIView.animate(withDuration: 0.6, animations: {
-                    card.center = center
-                    card.transform = CGAffineTransform(rotationAngle: rotationAngle)
-                    card.successImageView.alpha = isSuccess == true ? 1 : 0
-                    card.failImageView.alpha = isSuccess == false ? 1 : 0
-                    if isSuccess{
-                        card.setVideoBackgroundViewBorderColor(color: .pass, alpha: 1)
-                    } else {
-                        card.setVideoBackgroundViewBorderColor(color: .fail, alpha: 1)
-                    }
-                    
-                }) { [self] _ in
-                    if counter != cards.count-1 {
-                        print("DEBUG : \(counter) / \(cards.count - 1)")
-                        removeCard(card: card)
-                        counter += 1
-                        cards[counter]!.videoPlay()
-                    } else {
-                        didVideoClassificationComplete()
-                        removeCard(card: card)
-                    }
-                }
-            }
-        }
-    }
-    
-    @objc func backButtonClicked() {
-        self.navigationController?.popViewController(animated: true)
-        print("pop 가 됐습니다.")
-    }
-    
-    func didVideoClassificationComplete() {
-        levelButton.isEnabled = false
-        
-        saveButton.isHidden = false
-        successButton.isHidden = true
-        failButton.isHidden = true
-        
-        titleLabel.text = "분류 완료! 저장하기를 눌러주세요."
-        levelButton.setTitle("레벨", for: .normal)
-        
-        titleLabel.textColor = .orrGray3
-        levelButton.tintColor = .orrGray3
-        separator.backgroundColor = .orrGray3
-    }
+	
+	// 목업용 카드를 만들어줍니다.
+	func createSwipeableCard(_ completion: @escaping () -> Void) {
+		
+		var identifiers: [String] = []
+		for videoInfo in videoInfoArray {
+			identifiers.append(videoInfo.videoLocalIdentifier)
+		}
+		
+		let option = PHFetchOptions()
+		option.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: true)]
+		
+		let assets = PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: option)
+		cards = Array(repeating: nil, count: assets.count)
+		var totalCount = cards.count
+		
+		CustomIndicator.startLoading()
+		
+		for index in 0..<assets.count {
+			guard (assets[index].mediaType == PHAssetMediaType.video)
+					
+			else {
+				print("Not a valid video media type")
+				return
+			}
+			
+			let option = PHVideoRequestOptions()
+			option.isNetworkAccessAllowed = true
+			
+			PHCachingImageManager().requestAVAsset(forVideo: assets[index], options: option) { (assets, audioMix, info) in
+				let asset = assets as? AVURLAsset
+				
+				guard let url = asset?.url else {
+					return
+				}
+				
+				DispatchQueue.main.async {
+					let swipeCard = SwipeableCardVideoView(asset: AVAsset(url: url))
+					
+					if index == 0 {
+						swipeCard.embedVideo()
+						swipeCard.videoPlay()
+					}
+					
+					self.cards[index] = swipeCard
+					
+					totalCount -= 1
+					
+					if totalCount == 0 {
+						completion()
+					}
+				}
+			}
+		}
+	}
+	
+	// swipeCard가 SuperView에서 제거됩니다.
+	@objc func removeCard(card: UIView) {
+		card.removeFromSuperview()
+	}
+	
+	// Gesture
+	@objc func handlerCard(_ gesture: UIPanGestureRecognizer) {
+		if let card = gesture.view as? SwipeableCardVideoView {
+			let point = gesture.translation(in: view)
+			
+			card.center = CGPoint(x: view.center.x + point.x, y: view.center.y + point.y)
+			
+			let rotationAngle = point.x / view.bounds.width * 0.4
+			
+			if point.x > 0 {
+				card.successImageView.alpha = rotationAngle * 5
+				card.failImageView.alpha = 0
+				card.setVideoBackgroundViewBorderColor(color: .pass, alpha: rotationAngle * 5)
+			} else {
+				card.successImageView.alpha = 0
+				card.failImageView.alpha = -rotationAngle * 5
+				card.setVideoBackgroundViewBorderColor(color: .fail, alpha: -rotationAngle * 5)
+			}
+			
+			card.transform = CGAffineTransform(rotationAngle: rotationAngle)
+			
+			if gesture.state == .ended {
+				if card.center.x > self.view.bounds.width + 20 {
+					animateCard(rotationAngle: rotationAngle, videoResultType: .success)
+					return
+				}
+				
+				if card.center.x < -20 {
+					animateCard(rotationAngle: rotationAngle, videoResultType: .fail)
+					return
+				}
+				
+				UIView.animate(withDuration: 0.2) {
+					card.center = self.view.center
+					card.transform = .identity
+					card.successImageView.alpha = 0
+					card.failImageView.alpha = 0
+					card.setVideoBackgroundViewBorderColor(color: .clear, alpha: 1)
+				}
+			}
+		}
+	}
+	
+	@objc func pickLevel() {
+		let nextViewController = LevelPickerView()
+		self.navigationController?.present(nextViewController, animated: true)
+		nextViewController.delegate = self
+	}
+	
+	@objc func didFailButton() {
+		animateCard(rotationAngle: -0.4, videoResultType: .fail)
+	}
+	
+	@objc func didSuccessButton() {
+		animateCard(rotationAngle: 0.4, videoResultType: .success)
+	}
+	
+	@objc func tapSaveButton() {
+		// TODO: - 다음 뷰로 넘어가는 로직
+		DataManager.shared.createMultipleData(infoList: videoInfoArray)
+		self.navigationController?.popToRootViewController(animated: true)
+	}
+	
+	// swipeCard의 애니매이션 효과를 담당합니다.
+	func animateCard(rotationAngle: CGFloat, videoResultType: VideoResultType) {
+		
+		print(view.subviews.count)
+		var cardViews = view.subviews.filter({ ($0 as? SwipeableCardVideoView) != nil })
+		print("DDD ", cardViews.count)
+		
+		for view in cardViews {
+			if view == cards[counter] {
+				let center: CGPoint
+				let isSuccess: Bool
+				let  card = view as! SwipeableCardVideoView
+				
+				switch videoResultType {
+				case .fail:
+					center = CGPoint(x: card.center.x - view.bounds.width, y: card.center.y + 30)
+					isSuccess = false
+					
+				case .success:
+					center = CGPoint(x: card.center.x + view.bounds.width, y: card.center.y + 30)
+					isSuccess = true
+				}
+				
+				videoInfoArray[counter].isSucceeded = isSuccess
+				videoInfoArray[counter].problemLevel = currentSelectedLevel ?? 0
+				print(videoInfoArray[counter])
+				UIView.animate(withDuration: 0.6, animations: {
+					card.center = center
+					card.transform = CGAffineTransform(rotationAngle: rotationAngle)
+					card.successImageView.alpha = isSuccess == true ? 1 : 0
+					card.failImageView.alpha = isSuccess == false ? 1 : 0
+					if isSuccess{
+						card.setVideoBackgroundViewBorderColor(color: .pass, alpha: 1)
+					} else {
+						card.setVideoBackgroundViewBorderColor(color: .fail, alpha: 1)
+					}
+					
+				}) { [self] _ in
+					if counter != cards.count-1 {
+						print("DEBUG : \(counter) / \(cards.count - 1)")
+						removeCard(card: card)
+						counter += 1
+						cards[counter]!.videoPlay()
+					} else {
+						didVideoClassificationComplete()
+						removeCard(card: card)
+					}
+				}
+			}
+		}
+	}
+	
+	@objc func backButtonClicked() {
+		self.navigationController?.popViewController(animated: true)
+		print("pop 가 됐습니다.")
+	}
+	
+	func didVideoClassificationComplete() {
+		levelButton.isEnabled = false
+		
+		saveButton.isHidden = false
+		successButton.isHidden = true
+		failButton.isHidden = true
+		
+		titleLabel.text = "분류 완료! 저장하기를 눌러주세요."
+		levelButton.setTitle("레벨", for: .normal)
+		
+		titleLabel.textColor = .orrGray3
+		levelButton.tintColor = .orrGray3
+		separator.backgroundColor = .orrGray3
+	}
 }
 
 private extension SwipeableCardViewController {
-    
-    func setUpLayout() {
-
-        [levelButton, levelButtonImage].map {
-            self.buttonStackView.addArrangedSubview($0)
-        }
-
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(pickLevel))
-        buttonStackView.isUserInteractionEnabled = true
-        buttonStackView.addGestureRecognizer(tapGestureRecognizer)
-        
-        view.addSubview(titleLabel)
-        titleLabel.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().inset(104.0)
-        }
-        
-        view.addSubview(buttonStackView)
-        buttonStackView.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(titleLabel.snp.bottom).offset(24.0)
-            $0.centerX.equalToSuperview()
-        }
-        
-        levelButtonImage.snp.makeConstraints {
-            $0.height.equalTo(20.0)
-            $0.width.equalTo(20.0)
-        }
-        
-        view.addSubview(emptyVideoView)
-        emptyVideoView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.height.equalTo(420.0)
-            $0.leading.trailing.equalToSuperview().inset(60.0)
-        }
-        
-        view.addSubview(separator)
-        separator.snp.makeConstraints {
-            $0.centerX.equalToSuperview()
-            $0.top.equalTo(buttonStackView.snp.bottom).offset(8.0)
-            $0.height.equalTo(2.0)
-            $0.width.equalTo(70.0)
-        }
-        
-        emptyVideoView.addSubview(emptyVideoInformation)
-        emptyVideoInformation.snp.makeConstraints {
-            $0.center.equalTo(emptyVideoView.snp.center)
-        }
-        
-        view.addSubview(failButton)
-        failButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(64.0)
-            $0.leading.equalToSuperview().inset(48.0)
-            $0.height.equalTo(74.0)
-            $0.width.equalTo(74.0)
-        }
-        
-        view.addSubview(successButton)
-        successButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(64.0)
-            $0.trailing.equalToSuperview().inset(48.0)
-            $0.height.equalTo(74.0)
-            $0.width.equalTo(74.0)
-        }
-        
-        view.addSubview(saveButton)
-        saveButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(16.0)
-            $0.bottom.equalToSuperview().inset(30.0)
-            $0.height.equalTo(56.0)
-        }
-    }
+	
+	func setUpLayout() {
+		
+		[levelButton, levelButtonImage].map {
+			self.buttonStackView.addArrangedSubview($0)
+		}
+		
+		let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(pickLevel))
+		buttonStackView.isUserInteractionEnabled = true
+		buttonStackView.addGestureRecognizer(tapGestureRecognizer)
+		
+		view.addSubview(titleLabel)
+		titleLabel.snp.makeConstraints {
+			$0.centerX.equalToSuperview()
+			$0.top.equalToSuperview().inset(104.0)
+		}
+		
+		view.addSubview(buttonStackView)
+		buttonStackView.snp.makeConstraints {
+			$0.centerX.equalToSuperview()
+			$0.top.equalTo(titleLabel.snp.bottom).offset(24.0)
+			$0.centerX.equalToSuperview()
+		}
+		
+		levelButtonImage.snp.makeConstraints {
+			$0.height.equalTo(20.0)
+			$0.width.equalTo(20.0)
+		}
+		
+		view.addSubview(emptyVideoView)
+		emptyVideoView.snp.makeConstraints {
+			$0.center.equalToSuperview()
+			$0.height.equalTo(420.0)
+			$0.leading.trailing.equalToSuperview().inset(60.0)
+		}
+		
+		view.addSubview(separator)
+		separator.snp.makeConstraints {
+			$0.centerX.equalToSuperview()
+			$0.top.equalTo(buttonStackView.snp.bottom).offset(8.0)
+			$0.height.equalTo(2.0)
+			$0.width.equalTo(70.0)
+		}
+		
+		emptyVideoView.addSubview(emptyVideoInformation)
+		emptyVideoInformation.snp.makeConstraints {
+			$0.center.equalTo(emptyVideoView.snp.center)
+		}
+		
+		view.addSubview(failButton)
+		failButton.snp.makeConstraints {
+			$0.bottom.equalToSuperview().inset(64.0)
+			$0.leading.equalToSuperview().inset(48.0)
+			$0.height.equalTo(74.0)
+			$0.width.equalTo(74.0)
+		}
+		
+		view.addSubview(successButton)
+		successButton.snp.makeConstraints {
+			$0.bottom.equalToSuperview().inset(64.0)
+			$0.trailing.equalToSuperview().inset(48.0)
+			$0.height.equalTo(74.0)
+			$0.width.equalTo(74.0)
+		}
+		
+		view.addSubview(saveButton)
+		saveButton.snp.makeConstraints {
+			$0.leading.trailing.equalToSuperview().inset(16.0)
+			$0.bottom.equalToSuperview().inset(30.0)
+			$0.height.equalTo(56.0)
+		}
+	}
 }

--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
@@ -216,9 +216,7 @@ private extension SwipeableCardViewController {
 					
 					let swipeCard = SwipeableCardVideoView(asset: AVAsset(url: url))
 					
-					if index == 0 {
-						swipeCard.embedVideo()
-					}
+					swipeCard.embedVideo()
 					
 					self.cards[index] = swipeCard
 					

--- a/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
+++ b/OrrRock/OrrRock/Views/UploadView/SwipeableCardView/SwipeableCardViewController.swift
@@ -218,7 +218,6 @@ private extension SwipeableCardViewController {
 					
 					if index == 0 {
 						swipeCard.embedVideo()
-						swipeCard.videoPlay()
 					}
 					
 					self.cards[index] = swipeCard
@@ -345,7 +344,6 @@ private extension SwipeableCardViewController {
 						print("DEBUG : \(counter) / \(cards.count - 1)")
 						removeCard(card: card)
 						counter += 1
-						cards[counter]!.videoPlay()
 					} else {
 						didVideoClassificationComplete()
 						removeCard(card: card)


### PR DESCRIPTION
### 작업 내용 설명
1. 데이터 유실 원인 파악 및 해결
2. 기능만 구현해 놓은 코드 리팩토링
3. 기존 영상이 반복재생이 되지 않던 문제 해결

### 관련 이슈
- #106 

### 작업의 결과물
#### 1. '데이터 유실 원인 파악 및 해결' 작업 설명
<img src="https://user-images.githubusercontent.com/45965405/200389644-8d431f0b-9ae3-45d2-b483-2c317065722f.png"  width="500">  
  
- 사진에서 보이다시피 `requestAVAsset` [메서드](https://developer.apple.com/documentation/photokit/phimagemanager/1616935-requestavasset)를 통해 비동기적으로 데이터가 넘어오는 과정에서 몇몇 Asset이 (x 표시가 된 부분) nil값이 넘어옴  
    - `requestAVAsset` 메서드 특성 상 비동기 요청의 경우, Photos는 resultHandler블록을 두번 이상 호출 할 수 있음  
    - 그 과정에서 nil 값이 넘어왔을 때 `guard let`에서 return 해버려서 Asset 데이터가 유실됨  
    - 클라우드와 동기화가 되어 있는 Asset의 경우 간헐적으로 한번 호출로는 nil 값이 넘어옴  
    -  `PHVideoRequestOptions`을 따로  설정해 주지 않으면 `isNetworkAccessAllowed` [값이 디폴트로 false로 지정](https://developer.apple.com/documentation/photokit/phimagerequestoptions/1616934-isnetworkaccessallowed)되어 있음
    - `true`로 지정해 주었을 때 동기화가 되어있는 Asset도 정상적으로 넘어옴  
  
#### 2. '기능만 구현해 놓은 코드 리팩토링' 작업 설명
- 기존에 `totalCount`로 Asset의 수를 체크했던 코드를 `DispatchGroup`을 통한 Reference Counting으로 리팩토링
- `totalCount`가 0이 되었을 때 completionHandler로 반환했던 코드를 `countingGroup.notify`를 통해 반환

#### 참고
- [Jedd iOS Blog](https://zeddios.tistory.com/1151)
- [Jedd iOS Blog](https://zeddios.tistory.com/620)
- [stack overflow](https://stackoverflow.com/questions/40446026/phcacheimagemanager-requestavassetforvideo-returns-nil-avasset)

### 작업의 비고사항 및 한계점
- 업로드 영상이 100개가 넘어가면 로딩 시간이 걸림
    - 추후 코어 데이터 매니저의 영상 업로드 메서드 비동기 처리 필요

### To Reviewers
- 이 코드 로직 리팩토링 꽤나 힘들었지만 해결하니 재밌네요 ㅎㅎ

Close #106 
