### PR TITLE
[#121] fix - 영상이 삭제된 경우에 VideoDetailView 예외처리

### DIFF
--- a/OrrRock/OrrRock/ViewControllers/VideoDetailViewController/VideoDetailViewController.swift
+++ b/OrrRock/OrrRock/ViewControllers/VideoDetailViewController/VideoDetailViewController.swift
@@ -59,12 +59,12 @@ class VideoDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        loadVideoAsset()
+
         setNavigationBar()
         setUpLayout()
         setKeyboardObserver()
         setDefaultData()
-        
-        loadVideoAsset()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -299,6 +299,8 @@ private extension VideoDetailViewController {
             print("영상이 없음")
             return
         }
+        
+        self.videoAsset = videoAsset
     }
     
     func videoDataFomatter(videoLocalIdentifier: String) -> PHAsset? {

--- a/OrrRock/OrrRock/ViewControllers/VideoDetailViewController/VideoDetailViewController.swift
+++ b/OrrRock/OrrRock/ViewControllers/VideoDetailViewController/VideoDetailViewController.swift
@@ -7,6 +7,7 @@
 
 import AVFoundation
 import UIKit
+import Photos
 
 import SnapKit
 
@@ -22,6 +23,8 @@ class VideoDetailViewController: UIViewController {
     var videoInfoView = VideoInfoView()
     
     var videoInformation: VideoInformation!
+    var videoAsset: PHAsset?
+    
     var feedbackText: String?
     
     private var infoButton: UIBarButtonItem!
@@ -49,7 +52,7 @@ class VideoDetailViewController: UIViewController {
     
     // 영상 재생하는 뷰 (VideoPlayerView)
     lazy var videoPlayView: VideoPlayView = {
-        let view = VideoPlayView(videoInformation: videoInformation)
+        let view = VideoPlayView(videoAsset: videoAsset)
         self.view.addSubview(view)
         return view
     }()
@@ -60,6 +63,8 @@ class VideoDetailViewController: UIViewController {
         setUpLayout()
         setKeyboardObserver()
         setDefaultData()
+        
+        loadVideoAsset()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -284,6 +289,41 @@ extension VideoDetailViewController {
         self.navigationController?.navigationBar.layer.opacity = UserDefaults.standard.float(forKey: "navState")
     }
     
+}
+
+// Video 처리 관련 functions
+private extension VideoDetailViewController {
+    func loadVideoAsset() {
+        guard let videoAsset = videoDataFomatter(videoLocalIdentifier: videoInformation.videoLocalIdentifier ?? "") else {
+            // 영상이 없어 fetch를 하지 못한 경우
+            print("영상이 없음")
+            return
+        }
+    }
+    
+    func videoDataFomatter(videoLocalIdentifier: String) -> PHAsset? {
+        var videoIDArray: [String] = []
+        videoIDArray.append(videoLocalIdentifier)
+        
+        // LocalIdentifier를 기반으로 불러온 PHAsset을 PHFetchResult<PHAsset> 타입으로 변환
+        // 클래스에서 사용하는 것과 동일한 방법 및 규칙을 사용하여 가져오기 결과의 내용에 액세스
+        let phAsset = PHAsset.fetchAssets(withLocalIdentifiers: videoIDArray, options: .none)
+        // 참고 : https://developer.apple.com/documentation/photokit/phasset/1624783-fetchassets
+        
+        // 미디어가 존재하는지 확인하는 코드
+        guard phAsset.count != 0 else {
+            print("DEBUG: 앨범에서 비디오를 찾을 수 없습니다.")
+            return nil
+        }
+        
+        guard phAsset[0].mediaType == PHAssetMediaType.video
+        else {
+            print("DEBUG: 비디오 미디어가 존재하지 않습니다.")
+            return nil
+        }
+        
+        return phAsset[0]
+    }
 }
 
 // PHAsset 타입의 영상 데이터를 videoLocalIdentifier를 통해서 AVAsset으로 포매팅하는 매서드

--- a/OrrRock/OrrRock/Views/VideoDetailView/VideoPlayView.swift
+++ b/OrrRock/OrrRock/Views/VideoDetailView/VideoPlayView.swift
@@ -9,31 +9,44 @@ import AVFoundation
 import UIKit
 import Photos
 
+import SnapKit
+
 final class VideoPlayView: UIView {
-	
 	private lazy var videoBackgroundView: UIView = {
 		let view = UIView()
 		return view
 	}()
+    
+    private lazy var warningView: UIView = {
+        let view = UIView()
+        
+        let warningLabel = UILabel()
+        warningLabel.text = "앨범에서 영상이 삭제되었습니다."
+        warningLabel.textColor = .orrGray4
+        warningLabel.textAlignment = .center
+        
+        view.addSubview(warningLabel)
+        warningLabel.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        return view
+    }()
 	
-	var videoInformation : VideoInformation?
 	
 	var queuePlayer = AVQueuePlayer()
 	private var playerLooper: AVPlayerLooper?
 	private var playerLayer: AVPlayerLayer?
+	    
+    private var videoAsset: PHAsset?
 	
-	private var stringArray: [String]
-	
-	init(videoInformation : VideoInformation) {
-		self.videoInformation = videoInformation
-		self.stringArray = []
+	init(videoAsset: PHAsset?) {
+        self.videoAsset = videoAsset
 		super.init(frame: .zero)
 		
 		setUpLayout()
-		
-		// PHAsset 기본 메서드 fetchAssets의 포맷을 맞추기 위한 String 배열 생성 및 데이터 삽입
-		stringArray.append((videoInformation.videoLocalIdentifier ?? nil)!)
-		videoDataFomatter(videoLocalIdentifier: stringArray)
+        
+        loadVideo(videoAsset: videoAsset)
 	}
 	
 	required init?(coder: NSCoder) {
@@ -45,48 +58,32 @@ final class VideoPlayView: UIView {
 		
 		self.playerLayer?.frame = self.videoBackgroundView.bounds
 	}
-}
-
-// AVPlayerLayer에 AVAsset파일을 받아와서 띄워주는 코드
-private extension VideoPlayView {
-	
-	func videoDataFomatter(videoLocalIdentifier: [String]) {
-		// LocalIdentifier를 기반으로 불러온 PHAsset을 PHFetchResult<PHAsset> 타입으로 변환
-		// 클래스에서 사용하는 것과 동일한 방법 및 규칙을 사용하여 가져오기 결과의 내용에 액세스
-		let phasset = PHAsset.fetchAssets(withLocalIdentifiers: videoLocalIdentifier, options: .none)
-		// 참고 : https://developer.apple.com/documentation/photokit/phasset/1624783-fetchassets
-		
-		// 미디어가 존재하는지 확인하는 코드
-		guard (phasset[0].mediaType == PHAssetMediaType.video)
-		else {
-			print("비디오 미디어가 존재하지 않습니다.")
-			return
-		}
-		
-		// 비디오 Asset의 콘텐츠 및 상태를 나타내는 AVFoundation 개체가 비동기식으로 로드되도록 요청
-		// AVAsset?, AVAudioMix?, [AnyHashable : Any]? 타입으로 반환
-		PHCachingImageManager().requestAVAsset(forVideo: phasset[0], options: nil) { (assets, audioMix, info) in
-			// 참고 : https://developer.apple.com/documentation/photokit/phimagemanager/1616935-requestavasset
-			
-			// 비동기적으로 로드되는 AVFoundation 개체를 받아 Player로 재생
-			DispatchQueue.main.async {
-				let item = AVPlayerItem(asset: assets!)
-				self.queuePlayer = AVQueuePlayer()
-				let playerLayer = AVPlayerLayer(player: self.queuePlayer)
-				playerLayer.frame = self.videoBackgroundView.bounds
-				playerLayer.videoGravity = .resizeAspectFill
-				self.playerLayer = playerLayer
-				self.videoBackgroundView.layer.addSublayer(playerLayer)
-				self.queuePlayer.isMuted = true
-				self.playerLooper = AVPlayerLooper(player: self.queuePlayer, templateItem: item)
-				self.queuePlayer.play()
-			}
-		}
-	}
+    
+    func loadVideo(videoAsset: PHAsset?) {
+        guard let videoAsset = videoAsset else { return }
+        // 비디오 Asset의 콘텐츠 및 상태를 나타내는 AVFoundation 개체가 비동기식으로 로드되도록 요청
+        // AVAsset?, AVAudioMix?, [AnyHashable : Any]? 타입으로 반환
+        PHCachingImageManager().requestAVAsset(forVideo: videoAsset, options: nil) { (assets, audioMix, info) in
+            // 참고 : https://developer.apple.com/documentation/photokit/phimagemanager/1616935-requestavasset
+            
+            // 비동기적으로 로드되는 AVFoundation 개체를 받아 Player로 재생
+            DispatchQueue.main.async {
+                let item = AVPlayerItem(asset: assets!)
+                self.queuePlayer = AVQueuePlayer()
+                let playerLayer = AVPlayerLayer(player: self.queuePlayer)
+                playerLayer.frame = self.videoBackgroundView.bounds
+                playerLayer.videoGravity = .resizeAspectFill
+                self.playerLayer = playerLayer
+                self.videoBackgroundView.layer.addSublayer(playerLayer)
+                self.queuePlayer.isMuted = true
+                self.playerLooper = AVPlayerLooper(player: self.queuePlayer, templateItem: item)
+                self.queuePlayer.play()
+            }
+        }
+    }
 }
 
 private extension VideoPlayView {
-	
 	func setUpLayout() {
 		// AVPlayerLayer의 뒤에 위치할 뷰
 		self.addSubview(videoBackgroundView)
@@ -94,5 +91,13 @@ private extension VideoPlayView {
 			$0.top.leading.trailing.equalToSuperview()
 			$0.bottom.equalToSuperview().inset(50)
 		}
+        
+        if videoAsset == nil {
+            self.addSubview(warningView)
+            warningView.snp.makeConstraints {
+                $0.top.leading.trailing.equalToSuperview()
+                $0.bottom.equalToSuperview()
+            }
+        }
 	}
 }

--- a/OrrRock/OrrRock/Views/VideoDetailView/VideoPlayView.swift
+++ b/OrrRock/OrrRock/Views/VideoDetailView/VideoPlayView.swift
@@ -21,9 +21,10 @@ final class VideoPlayView: UIView {
         let view = UIView()
         
         let warningLabel = UILabel()
-        warningLabel.text = "앨범에서 영상이 삭제되었습니다."
+        warningLabel.text = "앨범에서 영상이 삭제되어\n해당 영상을 재생할 수 없습니다."
         warningLabel.textColor = .orrGray4
         warningLabel.textAlignment = .center
+        warningLabel.numberOfLines = 2
         
         view.addSubview(warningLabel)
         warningLabel.snp.makeConstraints {


### PR DESCRIPTION
### 작업 내용 설명
1. VideoDetailView에서 영상이 없는 경우에 영상 대신 "앨범에서 영상이 삭제되어 해당 영상을 재생할 수 없습니다." PlaceHolder를 보여줌.
2. 삭제된 영상에 대한 썸네일은 예외처리를 통해 기본 PlaceHolder Color를 보여줌.

### 관련 이슈
- #121

### 작업의 결과물
|영상 없는 HomeView|영상 없는 CollectionView|영상 없는 DetailView|전체화면 모드에서|
|---|---|---|---|
|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-08 at 16 39 02](https://user-images.githubusercontent.com/39216546/200506068-415d990f-3e3b-4393-8caf-c17784578494.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-08 at 16 39 09](https://user-images.githubusercontent.com/39216546/200506774-ec9a5d13-63e4-4ca5-a40d-7b599104ed2d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-08 at 16 39 12](https://user-images.githubusercontent.com/39216546/200506544-df4573f0-1634-4025-8fd5-c587c0cd2bcd.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-08 at 16 39 14](https://user-images.githubusercontent.com/39216546/200506557-6d6c25f2-6257-43b0-99b3-fe52935c66f8.png)|


### 작업의 비고사항 및 한계점
- 영상이 비어있는 경우 PlaceHolder에 넣을 데이터(썸네일 이미지) 추가해야 앱이 완성도 있을 것 같아요.
- 추후에 데이터 삭제 로직을 넣어 

### To Reviewers
- 사랑해요

Close #121 
