### PR TITLE
[#129] fix 홈화면 목록형으로 볼때 썸네일 깨짐 수정

### DIFF
--- a/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController+CollectionViewExtensions.swift
+++ b/OrrRock/OrrRock/ViewControllers/HomeViewController/HomeViewController+CollectionViewExtensions.swift
@@ -67,9 +67,8 @@ extension HomeViewController: UICollectionViewDataSource {
                            visitedGymName: flattenSortedVideoInfoData[indexPath.row].gymName,
                            level: "V\(flattenSortedVideoInfoData[indexPath.row].problemLevel)",
                            PF: flattenSortedVideoInfoData[indexPath.row].isSucceeded ? "성공" : "실패",
-                           thumbnail: flattenSortedVideoInfoData[indexPath.row].videoLocalIdentifier!.generateCardViewThumbnail(targetSize: CGSize(width: 50, height: 50))!)
-            
-            
+                           thumbnail: flattenSortedVideoInfoData[indexPath.row].videoLocalIdentifier!.generateCardViewThumbnail(targetSize: CGSize(width: 825, height: 825))!)
+
             return cell
         }
     }

--- a/OrrRock/OrrRock/Views/HomeView/HomeCollectionViewListCell.swift
+++ b/OrrRock/OrrRock/Views/HomeView/HomeCollectionViewListCell.swift
@@ -18,7 +18,10 @@ final class HomeCollectionViewListCell: UICollectionViewCell {
     private lazy var thumbnailView: UIImageView = {
         let view = UIImageView()
         view.layer.cornerRadius = 10
+        view.layer.masksToBounds = true
         view.backgroundColor = .orrGray3
+        view.contentMode = .scaleAspectFill
+
         return view
     }()
     
@@ -143,7 +146,7 @@ final class HomeCollectionViewListCell: UICollectionViewCell {
     func setUpData(visitedDate: String, visitedGymName: String, level: String, PF: String, thumbnail: UIImage) {
         visitedDateLabel.text = visitedDate
         gymNameLabel.text = visitedGymName
-        levelLabel.text = level
+        levelLabel.text = level == "V-1" ? "선택안함" : level
         PFLabel.text = PF
         thumbnailView.image = thumbnail
     }


### PR DESCRIPTION
### 작업 내용 설명
홈화면 목록형으로 볼때 썸네일 깨짐 수정
cornerRadius 미적용 이슈 해결

### 관련 이슈
- #129

### 작업의 결과물
|기존|개선|
|---|---|
|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/200599209-e964a9c4-8850-4f22-953f-80182ba3cf31.PNG">|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/200599252-f019f860-0c5b-44fb-a868-ef15bd3d0e3d.PNG">|

### 작업의 비고사항 및 한계점
- 야근은 있어서 한계는 없습니다.

### To Reviewers
- 몇줄 수정 안했습니당!!

Close #129 
