### PR TITLE
[#147] fix LevelAndPFSettingViewController 오토레이아웃 수정

### DIFF
--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -156,16 +156,17 @@ final class LevelAndPFSettingViewController: UIViewController {
         // card UI
         setUpLayout()
         
-        createSwipeableCard() {
+        createSwipeableCard() { [self] in
             self.cards.forEach { swipeCard in
                 // FIXME: 다시 수정해야 되는 코드
                 // 카드를 z축 기준 가장 상단에 위치하게 하는 코드
                 // self.view.bringSubviewToFront(swipeCard!)
                 self.view.insertSubview(swipeCard!, at: 0)
                 swipeCard!.snp.makeConstraints {
-                    $0.center.equalToSuperview()
-                    $0.height.equalTo(420.0)
-                    $0.leading.trailing.equalToSuperview().inset(60.0)
+                    $0.top.equalTo(self.emptyVideoView.snp.top)
+                    $0.bottom.equalTo(self.emptyVideoView.snp.bottom)
+                    $0.leading.equalTo(self.emptyVideoView.snp.leading)
+                    $0.trailing.equalTo(self.emptyVideoView.snp.trailing)
                 }
                 
                 self.view.sendSubviewToBack(self.emptyVideoView)
@@ -432,7 +433,7 @@ private extension LevelAndPFSettingViewController {
         view.addSubview(headerView)
         headerView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview()
-            $0.top.equalToSuperview().offset(105)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
         }
         
         headerView.addSubview(titleLabel)
@@ -448,20 +449,13 @@ private extension LevelAndPFSettingViewController {
         headerView.addSubview(levelStackView)
         levelStackView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(titleLabel.snp.bottom).offset(24.0)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(OrrPadding.padding3.rawValue)
             $0.centerX.equalToSuperview()
         }
         
         levelButtonImage.snp.makeConstraints {
             $0.height.equalTo(20.0)
             $0.width.equalTo(20.0)
-        }
-        
-        view.addSubview(emptyVideoView)
-        emptyVideoView.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.height.equalTo(420.0)
-            $0.leading.trailing.equalToSuperview().inset(60.0)
         }
         
         headerView.addSubview(separator)
@@ -473,14 +467,10 @@ private extension LevelAndPFSettingViewController {
             $0.width.equalTo(90.0)
         }
         
-        emptyVideoView.addSubview(emptyVideoInformation)
-        emptyVideoInformation.snp.makeConstraints {
-            $0.center.equalTo(emptyVideoView.snp.center)
-        }
-        
         view.addSubview(failButton)
         failButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(64.0)
+//            $0.bottom.equalToSuperview().inset(64.0)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-OrrPadding.padding3.rawValue)
             $0.leading.equalToSuperview().inset(48.0)
             $0.height.equalTo(74.0)
             $0.width.equalTo(74.0)
@@ -488,17 +478,32 @@ private extension LevelAndPFSettingViewController {
         
         view.addSubview(successButton)
         successButton.snp.makeConstraints {
-            $0.bottom.equalToSuperview().inset(64.0)
+//            $0.bottom.equalToSuperview().inset(64.0)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-OrrPadding.padding3.rawValue)
             $0.trailing.equalToSuperview().inset(48.0)
             $0.height.equalTo(74.0)
             $0.width.equalTo(74.0)
         }
         
+        view.addSubview(emptyVideoView)
+        emptyVideoView.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(separator.snp.bottom).offset(OrrPadding.padding4.rawValue)
+            $0.bottom.equalTo(successButton.snp.top).offset(-OrrPadding.padding4.rawValue)
+            $0.width.equalTo(emptyVideoView.snp.height).multipliedBy(0.5625)
+        }
+        
+        emptyVideoView.addSubview(emptyVideoInformation)
+        emptyVideoInformation.snp.makeConstraints {
+            $0.center.equalTo(emptyVideoView.snp.center)
+        }
+        
         view.addSubview(saveButton)
         saveButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(16.0)
-            $0.bottom.equalToSuperview().inset(30.0)
-            $0.height.equalTo(56.0)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-OrrPadding.padding3.rawValue)
+            $0.leading.equalTo(view).offset(OrrPadding.padding3.rawValue)
+            $0.trailing.equalTo(view).offset(-OrrPadding.padding3.rawValue)
+            $0.height.equalTo(56)
         }
     }
 }

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -156,7 +156,7 @@ final class LevelAndPFSettingViewController: UIViewController {
         // card UI
         setUpLayout()
         
-        createSwipeableCard() { [self] in
+        createSwipeableCard() {
             self.cards.forEach { swipeCard in
                 // FIXME: 다시 수정해야 되는 코드
                 // 카드를 z축 기준 가장 상단에 위치하게 하는 코드
@@ -469,7 +469,6 @@ private extension LevelAndPFSettingViewController {
         
         view.addSubview(failButton)
         failButton.snp.makeConstraints {
-//            $0.bottom.equalToSuperview().inset(64.0)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-OrrPadding.padding3.rawValue)
             $0.leading.equalToSuperview().inset(48.0)
             $0.height.equalTo(74.0)
@@ -478,7 +477,6 @@ private extension LevelAndPFSettingViewController {
         
         view.addSubview(successButton)
         successButton.snp.makeConstraints {
-//            $0.bottom.equalToSuperview().inset(64.0)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-OrrPadding.padding3.rawValue)
             $0.trailing.equalToSuperview().inset(48.0)
             $0.height.equalTo(74.0)

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -304,7 +304,7 @@ private extension LevelAndPFSettingViewController {
                 }
                 
                 UIView.animate(withDuration: 0.2) {
-                    card.center = self.view.center
+                    card.center = self.emptyVideoView.center
                     card.transform = .identity
                     card.successImageView.alpha = 0
                     card.failImageView.alpha = 0


### PR DESCRIPTION
### 작업 내용 설명
1. LevelAndPFSettingViewController 오토레이아웃 수정
2. 카드의 비율을 16:9로 고정
3. 하단 이미지 참조

### 관련 이슈
- #147

### 작업의 결과물
#### 수정전
|홈버튼 없는 모델|홈버튼이 있는모델|
|---|---|
|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/201677089-afb8e5c8-8cf2-4d6a-8da6-30180f994e66.png">|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/201677177-d528c2be-4d0c-4252-9281-677a8cf46aaa.png">|
|13ProMax|SE3|


#### 수정후
|홈버튼 없는 모델|홈버튼이 있는모델|
|---|---|
|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/201676906-d0036fce-4260-4963-be4f-8d14dc669c6c.png">|<img width="200" alt="image" src="https://user-images.githubusercontent.com/103024840/201676766-a4b8b8f7-dfae-4614-a964-878e5653f0bf.png">|
|13ProMax|SE3|


### 작업의 비고사항 및 한계점
- 저에게 한계란 없습니다.
- 다른 분들도 해당 뷰에 작업이 필요하다고 하셔서 먼저 올립니다.
- 해당 이슈는 아직 종료되지 않았습니다.

### To Reviewers
- 리뷰어에게 중점적으로 살펴봐줬으면 하는 내용

Close 
아직이슈가 끝나지 않았습니다.
