### PR TITLE
[#165] fix - request가 불가능한 영상이 들어왔을 경우 경고창과 함께 뒤로 돌아가는 로직 구현

### DIFF
--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -232,11 +232,23 @@ private extension LevelAndPFSettingViewController {
             let option = PHVideoRequestOptions()
             option.isNetworkAccessAllowed = true
             
-            PHCachingImageManager().requestAVAsset(forVideo: assets[index], options: option) { (assets, audioMix, info) in
+            PHImageManager().requestAVAsset(forVideo: assets[index], options: option) { (assets, audioMix, info) in
                 
                 let asset = assets as? AVURLAsset
                 
                 guard let url = asset?.url else {
+                    // 영상이 불러와지지 않을 시 경고창과 함께 뒤로 돌아가는 로직
+                    let alret = UIAlertController(title: "영상을 불러올 수 없습니다.", message: "영상을 불러오는 데 오류가 발생하였습니다.\n\n영상의 포맷이 일반적이지 않은 영상일 수 있으니 확인 후 다시 업로드 해 주세요", preferredStyle: .alert)
+                    
+                    let confirm = UIAlertAction(title: "확인", style: .default) { _ in
+                        self.navigationController?.popViewController(animated: true)
+                    }
+                    
+                    alret.addAction(confirm)
+                    
+                    self.present(alret, animated: true) {
+                        CustomIndicator.stopLoading()
+                    }
                     return
                 }
                 


### PR DESCRIPTION
### 작업 내용 설명
1. 원래 이미지 캐싱을 위한 클래스 `PHCachingImageManager`를 상위 오브젝트인 `PHImageManager`로 변경
2. `AVAsset`으로 불러올 수 없어 `nil`값이 호출되는 시점에서 경고창과 함께 뒤로 돌아가도록 구현

### 관련 이슈
- #165 

### 작업의 결과물
|기존 상황|변경 상황|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/45965405/201708286-8e518dd7-d869-46fe-a619-2e5fe8d190e0.png"  width="200">|<img src="https://user-images.githubusercontent.com/45965405/201708337-d4222e22-42c7-4f32-8dcf-8cf5ed135efa.png"  width="200">|
|무한 로딩 현상과 함께 다음 동작을 할 수 없음|경고창과 함께 다시 영상을 선택할 수 있음|

### 작업의 비고사항 및 한계점
- 지금 "슬로우모션비디오"와 "클라우드연동비디오"에 대해 예외 처리를 통해 불러올 수 없는 에러를 수정했으나 
- 다른 예상치 못한 일반적이지 않은 포맷의 영상이 들어올 수도 있다는 판단에 
- `nil` 값이 들어와서 레퍼런스 카운팅이 되지 않아 무한 로딩 현상이 걸릴 수 있을 법한 모든 가능성을 차단하기 위해 이와 같이 구현하였습니다.

### To Reviewers
- 경고창에 뜨는 문구에 대해서 제가 임의로 작성을 하긴 했는데 다른 좋은 워딩을 함께 고려하면 좋을 것 같습니다.

Close #165 
