### PR TITLE
[#171] feat - 영상이 백그라운드에서 재생 정지된 채 로드되고 상단 노출 되었을 때 재생되는 기능 추가

### DIFF
--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -264,6 +264,10 @@ private extension LevelAndPFSettingViewController {
                     
                     // Asset 카운팅 -1
                     countingGroup.leave()
+                    
+                    // 첫번째 카드를 재생시켜주는 코드
+                    let firstCard = self.cards[0] as! SwipeableCardVideoView
+                    firstCard.queuePlayer.play()
                 }
                 // Asset 카운팅이 0이 되었을 때 completionHandler로 반환
                 countingGroup.notify(queue: DispatchQueue.main) {

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -370,6 +370,11 @@ private extension LevelAndPFSettingViewController {
                 let center: CGPoint
                 let isSuccess: Bool
                 let card = view as! SwipeableCardVideoView
+                // 다음에 나올 카드
+                let nextCard = cards[counter + 1] as! SwipeableCardVideoView
+                
+                // 이전 카드가 스와이프가 되었을 때 다음에 나올 카드가 재생
+                nextCard.queuePlayer.play()
                 
                 switch videoResultType {
                 case .fail:

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -370,12 +370,11 @@ private extension LevelAndPFSettingViewController {
                 let center: CGPoint
                 let isSuccess: Bool
                 let card = view as! SwipeableCardVideoView
-                let nextCard = view as! SwipeableCardVideoView
                 
                 // 마지막 카드가 아닐 때 다음 카드를 재생
                 if counter != cards.count-1 {
                     // 다음에 나올 카드
-                    let nextCard = cards[counter + 1] as! SwipeableCardVideoView
+                    guard let nextCard = cards[counter + 1] as? SwipeableCardVideoView else { return }
                     // 이전 카드가 스와이프가 되었을 때 다음에 나올 카드가 재생
                     nextCard.queuePlayer.play()
                 }

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -266,8 +266,8 @@ private extension LevelAndPFSettingViewController {
                     countingGroup.leave()
                     
                     // 첫번째 카드를 재생시켜주는 코드
-                    let firstCard = self.cards[0] as! SwipeableCardVideoView
-                    firstCard.queuePlayer.play()
+                    let firstCard = self.cards[0] as? SwipeableCardVideoView
+                    firstCard?.queuePlayer.play()
                 }
                 // Asset 카운팅이 0이 되었을 때 completionHandler로 반환
                 countingGroup.notify(queue: DispatchQueue.main) {

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -370,11 +370,15 @@ private extension LevelAndPFSettingViewController {
                 let center: CGPoint
                 let isSuccess: Bool
                 let card = view as! SwipeableCardVideoView
-                // 다음에 나올 카드
-                let nextCard = cards[counter + 1] as! SwipeableCardVideoView
+                let nextCard = view as! SwipeableCardVideoView
                 
-                // 이전 카드가 스와이프가 되었을 때 다음에 나올 카드가 재생
-                nextCard.queuePlayer.play()
+                // 마지막 카드가 아닐 때 다음 카드를 재생
+                if counter != cards.count-1 {
+                    // 다음에 나올 카드
+                    let nextCard = cards[counter + 1] as! SwipeableCardVideoView
+                    // 이전 카드가 스와이프가 되었을 때 다음에 나올 카드가 재생
+                    nextCard.queuePlayer.play()
+                }
                 
                 switch videoResultType {
                 case .fail:

--- a/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
@@ -82,7 +82,7 @@ extension SwipeableCardVideoView {
 		self.videoBackgroundView.layer.addSublayer(playerLayer)
 		self.queuePlayer.isMuted = true
 		self.playerLooper = AVPlayerLooper(player: self.queuePlayer, templateItem: item)
-		self.queuePlayer.play()
+		self.queuePlayer.pause()
 	}
 }
 

--- a/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
@@ -15,9 +15,9 @@ final class SwipeableCardVideoView: UIView {
 	
 	var video: VideoInfo?
 	let cornerRadius: CGFloat = 10
+    var queuePlayer = AVQueuePlayer()
 	private var player = AVPlayer()
 	private var playerLayer: AVPlayerLayer?
-	private var queuePlayer = AVQueuePlayer()
 	private var playerLooper: AVPlayerLooper?
 	private var asset: AVAsset
 	


### PR DESCRIPTION
### 작업 내용 설명
1. 디폴트로 카드 재생을 일시정지 상태로 카드를 불러오도록 수정
2. `cards` 배열의 0번째 인덱스의 카드를 재생
3. 스와이프 애니매이션이 끝나면 다음 카드의 영상을 재생

### 관련 이슈
- #171 

### 작업의 결과물
|수정 전|수정 후|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/45965405/201926058-1dc54b58-b36a-4648-aac4-9131fca53065.gif"  width="200">|<img src="https://user-images.githubusercontent.com/45965405/201926109-40fe5bff-ef2c-432f-9454-005d676121f9.gif"  width="200">  |
|백그라운드에서 카드 영상이 재생되고 있음|가장 상단에 있는 카드 영상만 재생되고 있음|  
  
> **테스트 환경**
> - iPhone 12 Pro (A14 칩셋 / 6GB RAM)
> - 4K 60fps HEVC 포맷 30초 HDR 영상
  
수정 전 : 고용량 영상 5개 부터 프레임 드랍이 발생  
수정 후 : 고용량 영상 20개까지도 프레임 드랍 발생하지 않음

### 작업의 비고사항 및 한계점
- 고용량 영상을 업로드 하는 과정에서 로딩 시간이 꽤 오래 걸림  
    - 테스트 환경 기준 영상 20개 업로드 5초
    - 영상은 비동기적으로 불러오기 때문에 영상은 재생은 되지만,  
       영상 업로드와 영상 재생이 겹쳐져서 5초정도 영상 끊김이 있음

### To Reviewers
- 추후 고용량 영상을 업로드하는데 드는 시간을 줄이는 작업도 해야할 것 같아요

Close #171 
