### PR TITLE
[#152] fix - VideoCollectionView 하트 이미지 위치 조절

### DIFF
--- a/OrrRock/OrrRock/VideoDetail/Cell/VideoCollectionViewCustomCell.swift
+++ b/OrrRock/OrrRock/VideoDetail/Cell/VideoCollectionViewCustomCell.swift
@@ -91,8 +91,8 @@ class VideoCollectionViewCell : UICollectionViewCell {
         }
         self.addSubview(heartImage)
         heartImage.snp.makeConstraints {
-            $0.trailing.equalTo(self.snp.trailing).offset(-8)
-            $0.top.equalTo(self.snp.top).offset(8)
+            $0.trailing.equalTo(self.snp.trailing).offset(-OrrPadding.padding2.rawValue)
+            $0.top.equalTo(self.snp.top).offset(OrrPadding.padding2.rawValue)
         }
         self.addSubview(cellBlurView)
         cellBlurView.snp.makeConstraints {

--- a/OrrRock/OrrRock/VideoDetail/Cell/VideoCollectionViewCustomCell.swift
+++ b/OrrRock/OrrRock/VideoDetail/Cell/VideoCollectionViewCustomCell.swift
@@ -91,8 +91,8 @@ class VideoCollectionViewCell : UICollectionViewCell {
         }
         self.addSubview(heartImage)
         heartImage.snp.makeConstraints {
-            $0.leading.equalTo(cellLabel.snp.trailing).offset(1)
-            $0.centerY.equalTo(cellLabel.snp.centerY)
+            $0.trailing.equalTo(self.snp.trailing).offset(-8)
+            $0.top.equalTo(self.snp.top).offset(8)
         }
         self.addSubview(cellBlurView)
         cellBlurView.snp.makeConstraints {


### PR DESCRIPTION
### 작업 내용 설명
1. VideoCollectionView의 하트이미지의 위치를 좌하단에서 우상단으로 변경하였습니다.


### 관련 이슈
- #152

### 작업의 결과물
<img width="488" alt="image" src="https://user-images.githubusercontent.com/72395020/202370227-fa43ba9c-8760-4548-9c9a-e551c52f305b.png">


-확인을 위해 하트의 색상을 검정으로 임시 변경하였습니다.(현재는 하양)


### To Reviewers
- 감사합니다.

Close #152 
