### PR TITLE
[#189] design - HomeView UI 수정

### DIFF
--- a/OrrRock/OrrRock/Home/Cell/HomeTableViewHeader.swift
+++ b/OrrRock/OrrRock/Home/Cell/HomeTableViewHeader.swift
@@ -12,6 +12,12 @@ import SnapKit
 class HomeTableViewHeader: UITableViewHeaderFooterView {
     static let identifier: String = "HomeTableViewHeader"
     
+    private lazy var backgroundSubview: UIView = {
+       let view = UIView()
+        view.backgroundColor = .orrWhite
+        return view
+    }()
+    
     private lazy var primaryTitleLabel: UILabel = {
         let view = UILabel()
         view.font = .systemFont(ofSize: 20, weight: .bold)
@@ -29,7 +35,7 @@ class HomeTableViewHeader: UITableViewHeaderFooterView {
     private lazy var roundCornerView: UIView = {
         let view = UIView()
         view.backgroundColor = .orrWhite
-        view.layer.cornerRadius = 10
+        view.layer.cornerRadius = 8
         return view
     }()
     
@@ -42,17 +48,24 @@ class HomeTableViewHeader: UITableViewHeaderFooterView {
         secondaryTitleLabel.text = secondaryTitle
         
         setUpLayout()
-        contentView.backgroundColor = .orrWhite
+        contentView.backgroundColor = .clear
     }
 }
 
 extension HomeTableViewHeader {
     func setUpLayout() {
+        contentView.addSubview(backgroundSubview)
+        backgroundSubview.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.top.equalToSuperview().inset(5)
+        }
+        
+        
         contentView.addSubview(roundCornerView)
         roundCornerView.snp.makeConstraints {
             $0.width.equalTo(contentView.snp.width)
             $0.height.equalTo(10)
-            $0.bottom.equalTo(contentView.snp.top).offset(5)
+            $0.bottom.equalTo(backgroundSubview.snp.top).offset(5)
         }
         
         contentView.addSubview(secondaryTitleLabel)

--- a/OrrRock/OrrRock/Home/HomeViewController.swift
+++ b/OrrRock/OrrRock/Home/HomeViewController.swift
@@ -45,13 +45,15 @@ final class HomeViewController : UIViewController {
     }
     
     private let headerView: UIView = {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 160))
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 170))
         
         let gradientLayer = CAGradientLayer()
         gradientLayer.colors = [UIColor.orrGray1!.cgColor, UIColor.orrGray1!.withAlphaComponent(0).cgColor]
-        gradientLayer.locations = [0.75, 0.9]
+        gradientLayer.locations = [0.61, 0.82]
         gradientLayer.frame = view.bounds
+        
         view.layer.addSublayer(gradientLayer)
+        view.isUserInteractionEnabled = false
         
         return view
     }()
@@ -156,6 +158,9 @@ final class HomeViewController : UIViewController {
         view.showsVerticalScrollIndicator = false
         view.backgroundColor = UIColor.clear
         view.separatorStyle = .none
+
+        // 테이블뷰의 카드들이 시작되는 지점을 아래로 옮겨, UI 구성
+        view.tableHeaderView = UIView(frame: CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 0, height: 20)))
         
         // 앨범형, 목록형 셀 간격을 맞추기 위한 offset을 적용
         view.sectionHeaderTopPadding = CGFloat(OrrPadding.padding3.rawValue - 4)
@@ -230,7 +235,7 @@ final class HomeViewController : UIViewController {
         
         self.view.addSubview(homeTableView)
         homeTableView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(115)
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(104)
             $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottom)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading).inset(OrrPadding.padding3.rawValue)
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing).inset(OrrPadding.padding3.rawValue)
@@ -239,7 +244,7 @@ final class HomeViewController : UIViewController {
         self.view.addSubview(headerView)
         headerView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.height.equalTo(160)
+            $0.height.equalTo(170)
             $0.leading.equalTo(view.safeAreaLayoutGuide.snp.leading)
             $0.trailing.equalTo(view.safeAreaLayoutGuide.snp.trailing)
         }
@@ -266,7 +271,7 @@ final class HomeViewController : UIViewController {
         
         self.view.addSubview(tableViewSegmentControl)
         tableViewSegmentControl.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(CGFloat(OrrPadding.padding6.rawValue))
+            $0.top.equalTo(titleLabel.snp.bottom).offset(CGFloat(OrrPadding.padding4.rawValue))
             $0.leading.trailing.equalToSuperview().inset(CGFloat(OrrPadding.padding3.rawValue))
             $0.height.equalTo(48)
         }


### PR DESCRIPTION
### 작업 내용 설명
1. HeaderView 크기 수정
2. HeaderView의 Gradient 범위 및 값 수정
3. Gradient 영역 내에 있어도 터치가 가능하도록 상단영역의 UserInteractive 차단
4. 기타 UI detail 수정

### 관련 이슈
- #189 

### 작업의 결과물

<img width="355" alt="스크린샷 2022-11-17 오후 5 00 47" src="https://user-images.githubusercontent.com/39216546/202390777-50e0cf45-5865-4e5a-b243-56ab13a2f972.png"><img width="355" alt="스크린샷 2022-11-17 오후 5 00 42" src="https://user-images.githubusercontent.com/39216546/202390809-f3971354-3052-464e-acc7-f980a1994acc.png">



### 작업의 비고사항 및 한계점
- 이후에 HeaderView의 UI를 변경하고 싶다면 다음의 작업을 수행해야 합니다!!
  - HeaderView 선언부에서 view의 height 변경 (gradient 설정을 위함)
  - HeaderView SnapKit layout 지정부에서 height 변경 (기기대응을 위함)
  - Gradient 범위 변경 (최상단과 최하단을 [0, 1]로 하여, 비율로 값을 입력)

### To Reviewers
- 사랑해요

Close #189
