### PR TITLE
[#166] feat - 영상 스와이프 뷰에서 총 영상 개수와 남은 영상 개수 띄워주는 작업

### DIFF
--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -19,6 +19,8 @@ final class LevelAndPFSettingViewController: UIViewController {
     private var cards: [SwipeableCardVideoView?] = []
     private var counter: Int = 0
     private var currentSelectedLevel = -1
+    private var selectedCard: Int = 0
+    private var classifiedCard: Int = 0
     
     private lazy var headerView: UIView = {
         let view = UIView()
@@ -209,6 +211,8 @@ private extension LevelAndPFSettingViewController {
         let assets = PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: option)
         // PHFetchResult<PHAsset>의 Asset 개수만큼 배열 공간 할당
         cards = Array(repeating: nil, count: assets.count)
+        // 선택된 카드의 개수
+        selectedCard = cards.count
         // Asset 카운팅을 위한 디스패치 그룹
         let countingGroup = DispatchGroup()
         
@@ -251,7 +255,7 @@ private extension LevelAndPFSettingViewController {
                 }
                 
                 // Main Thread에서 View를 디스패치 그룹
-                DispatchQueue.main.async(group: countingGroup) {
+                DispatchQueue.main.async(group: countingGroup) { [self] in
                     
                     let swipeCard = SwipeableCardVideoView(asset: AVAsset(url: url))
                     
@@ -262,6 +266,10 @@ private extension LevelAndPFSettingViewController {
                     // Asset 카운팅 -1
                     countingGroup.leave()
                     
+                    // 분류된 카드 번호 넘버링
+                    classifiedCard = index + 1
+                    // '분류된 카드 / 선택된 카드' 형식의 문자열 값을 넘겨주는 메서드
+                    swipeCard.getCardLabelText(labelText: "\(classifiedCard)/\(selectedCard)")
                     // 첫번째 카드를 재생시켜주는 코드
                     let firstCard = self.cards[0] as? SwipeableCardVideoView
                     firstCard?.queuePlayer.play()

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -261,7 +261,7 @@ private extension LevelAndPFSettingViewController {
                     
                     swipeCard.embedVideo()
                     
-                    self.cards[index] = swipeCard
+                    cards[index] = swipeCard
                     
                     // Asset 카운팅 -1
                     countingGroup.leave()
@@ -271,7 +271,7 @@ private extension LevelAndPFSettingViewController {
                     // '분류된 카드 / 선택된 카드' 형식의 문자열 값을 넘겨주는 메서드
                     swipeCard.getCardLabelText(labelText: "\(classifiedCard)/\(selectedCard)")
                     // 첫번째 카드를 재생시켜주는 코드
-                    let firstCard = self.cards[0] as? SwipeableCardVideoView
+                    let firstCard = cards[0] as? SwipeableCardVideoView
                     firstCard?.queuePlayer.play()
                 }
                 // Asset 카운팅이 0이 되었을 때 completionHandler로 반환

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -158,9 +158,6 @@ final class LevelAndPFSettingViewController: UIViewController {
         
         createSwipeableCard() {
             self.cards.forEach { swipeCard in
-                // FIXME: 다시 수정해야 되는 코드
-                // 카드를 z축 기준 가장 상단에 위치하게 하는 코드
-                // self.view.bringSubviewToFront(swipeCard!)
                 self.view.insertSubview(swipeCard!, at: 0)
                 swipeCard!.snp.makeConstraints {
                     $0.top.equalTo(self.emptyVideoView.snp.top)

--- a/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
@@ -12,121 +12,121 @@ import AVKit
 import AVFoundation
 
 final class SwipeableCardVideoView: UIView {
-	
-	var video: VideoInfo?
-	let cornerRadius: CGFloat = 10
+    
+    var video: VideoInfo?
+    let cornerRadius: CGFloat = 10
     var queuePlayer = AVQueuePlayer()
-	private var player = AVPlayer()
-	private var playerLayer: AVPlayerLayer?
-	private var playerLooper: AVPlayerLooper?
-	private var asset: AVAsset
-	
-	private lazy var videoBackgroundView: UIView = {
-		let view = UIView()
-		view.backgroundColor = .orrGray3
-		view.layer.borderWidth = 3
-		view.layer.cornerRadius = cornerRadius
-		view.layer.borderColor = UIColor.white.cgColor
-		// 스와이프 뷰에서 카드들이 다중 터치가 되지 않게 막는 코드
-		view.isExclusiveTouch = true
-		
-		return view
-	}()
-	
-	let successImageView: UIImageView = {
-		let imageView = UIImageView()
-		imageView.image = UIImage(named: "success")
-		imageView.alpha = 0.0
-		
-		return imageView
-	}()
-	
-	let failImageView: UIImageView = {
-		let imageView = UIImageView()
-		imageView.image = UIImage(named: "fail")
-		imageView.alpha = 0.0
-		
-		return imageView
-	}()
-	
-	init(asset: AVAsset) {
-		self.asset = asset
-		super.init(frame: .zero)
-		
-		setUpLayout()
-		embedVideo()
-	}
-	
-	required init?(coder: NSCoder) {
-		fatalError()
-	}
-	
-	override func layoutSubviews() {
-		super.layoutSubviews()
-		
-		self.playerLayer?.frame = self.videoBackgroundView.bounds
-		self.playerLayer?.masksToBounds = true
-		self.playerLayer?.cornerRadius = cornerRadius
-	}
+    private var player = AVPlayer()
+    private var playerLayer: AVPlayerLayer?
+    private var playerLooper: AVPlayerLooper?
+    private var asset: AVAsset
+    
+    private lazy var videoBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .orrGray3
+        view.layer.borderWidth = 3
+        view.layer.cornerRadius = cornerRadius
+        view.layer.borderColor = UIColor.white.cgColor
+        // 스와이프 뷰에서 카드들이 다중 터치가 되지 않게 막는 코드
+        view.isExclusiveTouch = true
+        
+        return view
+    }()
+    
+    let successImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "success")
+        imageView.alpha = 0.0
+        
+        return imageView
+    }()
+    
+    let failImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "fail")
+        imageView.alpha = 0.0
+        
+        return imageView
+    }()
+    
+    init(asset: AVAsset) {
+        self.asset = asset
+        super.init(frame: .zero)
+        
+        setUpLayout()
+        embedVideo()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.playerLayer?.frame = self.videoBackgroundView.bounds
+        self.playerLayer?.masksToBounds = true
+        self.playerLayer?.cornerRadius = cornerRadius
+    }
 }
 
 extension SwipeableCardVideoView {
-	
-	func embedVideo() {
-		let item = AVPlayerItem(asset: asset)
-		self.queuePlayer = AVQueuePlayer()
-		let playerLayer = AVPlayerLayer(player: self.queuePlayer)
-		playerLayer.frame = self.videoBackgroundView.bounds
-		playerLayer.videoGravity = .resizeAspectFill
-		self.playerLayer = playerLayer
-		self.videoBackgroundView.layer.addSublayer(playerLayer)
-		self.queuePlayer.isMuted = true
-		self.playerLooper = AVPlayerLooper(player: self.queuePlayer, templateItem: item)
-		self.queuePlayer.pause()
-	}
+    
+    func embedVideo() {
+        let item = AVPlayerItem(asset: asset)
+        self.queuePlayer = AVQueuePlayer()
+        let playerLayer = AVPlayerLayer(player: self.queuePlayer)
+        playerLayer.frame = self.videoBackgroundView.bounds
+        playerLayer.videoGravity = .resizeAspectFill
+        self.playerLayer = playerLayer
+        self.videoBackgroundView.layer.addSublayer(playerLayer)
+        self.queuePlayer.isMuted = true
+        self.playerLooper = AVPlayerLooper(player: self.queuePlayer, templateItem: item)
+        self.queuePlayer.pause()
+    }
 }
 
 private extension SwipeableCardVideoView {
-	
-	func setUpLayout() {
-		self.addSubview(videoBackgroundView)
-		videoBackgroundView.snp.makeConstraints {
-			$0.edges.equalToSuperview()
-		}
-		
-		self.addSubview(successImageView)
-		successImageView.snp.makeConstraints {
-			$0.top.equalTo(videoBackgroundView.snp.top).offset(16.0)
-			$0.leading.equalTo(videoBackgroundView.snp.leading).offset(16.0)
-			$0.height.equalTo(30.0)
-			$0.width.equalTo(150.0)
-		}
-		
-		self.addSubview(failImageView)
-		failImageView.snp.makeConstraints {
-			$0.top.equalTo(videoBackgroundView.snp.top).offset(16.0)
-			$0.trailing.equalTo(videoBackgroundView.snp.trailing).offset(-16.0)
-			$0.height.equalTo(30.0)
-			$0.width.equalTo(100.0)
-		}
-	}
+    
+    func setUpLayout() {
+        self.addSubview(videoBackgroundView)
+        videoBackgroundView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        self.addSubview(successImageView)
+        successImageView.snp.makeConstraints {
+            $0.top.equalTo(videoBackgroundView.snp.top).offset(16.0)
+            $0.leading.equalTo(videoBackgroundView.snp.leading).offset(16.0)
+            $0.height.equalTo(30.0)
+            $0.width.equalTo(150.0)
+        }
+        
+        self.addSubview(failImageView)
+        failImageView.snp.makeConstraints {
+            $0.top.equalTo(videoBackgroundView.snp.top).offset(16.0)
+            $0.trailing.equalTo(videoBackgroundView.snp.trailing).offset(-16.0)
+            $0.height.equalTo(30.0)
+            $0.width.equalTo(100.0)
+        }
+    }
 }
 
 extension SwipeableCardVideoView {
-	
-	func setVideoBackgroundViewBorderColor(color: VideoBackgroundViewBorderColor,alpha: CGFloat) {
-		var r : CGFloat = 0.0
-		var g : CGFloat = 0.0
-		var b : CGFloat = 0.0
-		
-		switch color {
-		case.pass :
-			r = 48; g = 176; b = 199
-		case .fail :
-			r = 242; g = 52; b = 52
-		case .clear :
-			r = 255; g = 255; b = 255
-		}
-		videoBackgroundView.layer.borderColor = UIColor(red:r/255.0, green:g/255.0, blue:b/255.0, alpha: 1.0).cgColor
-	}
+    
+    func setVideoBackgroundViewBorderColor(color: VideoBackgroundViewBorderColor,alpha: CGFloat) {
+        var r : CGFloat = 0.0
+        var g : CGFloat = 0.0
+        var b : CGFloat = 0.0
+        
+        switch color {
+        case.pass :
+            r = 48; g = 176; b = 199
+        case .fail :
+            r = 242; g = 52; b = 52
+        case .clear :
+            r = 255; g = 255; b = 255
+        }
+        videoBackgroundView.layer.borderColor = UIColor(red:r/255.0, green:g/255.0, blue:b/255.0, alpha: 1.0).cgColor
+    }
 }

--- a/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
@@ -85,6 +85,11 @@ final class SwipeableCardVideoView: UIView {
         self.playerLayer?.masksToBounds = true
         self.playerLayer?.cornerRadius = cornerRadius
     }
+    
+    func getCardLabelText(labelText:String){
+        countVideoLabel.text = labelText
+    }
+    
 }
 
 extension SwipeableCardVideoView {

--- a/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
+++ b/OrrRock/OrrRock/Upload/UIComponent/View/SwipeableCardVideoView.swift
@@ -49,6 +49,23 @@ final class SwipeableCardVideoView: UIView {
         return imageView
     }()
     
+    private lazy var countVideoView:  UIView = {
+        let view = UIView()
+        view.backgroundColor = .orrBlack?.withAlphaComponent(0.6)
+        view.layer.cornerRadius = 10
+        
+        return view
+    }()
+    
+    lazy var countVideoLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.textColor = .orrWhite
+        label.font = .systemFont(ofSize: 12.0, weight: .regular)
+        
+        return label
+    }()
+    
     init(asset: AVAsset) {
         self.asset = asset
         super.init(frame: .zero)
@@ -108,6 +125,19 @@ private extension SwipeableCardVideoView {
             $0.trailing.equalTo(videoBackgroundView.snp.trailing).offset(-16.0)
             $0.height.equalTo(30.0)
             $0.width.equalTo(100.0)
+        }
+        
+        self.addSubview(countVideoView)
+        countVideoView.snp.makeConstraints {
+            $0.bottom.equalTo(videoBackgroundView.snp.bottom).inset(OrrPadding.padding3.rawValue)
+            $0.centerX.equalTo(videoBackgroundView.snp.centerX)
+            $0.height.equalTo(24)
+            $0.width.equalTo(71)
+        }
+        
+        countVideoView.addSubview(countVideoLabel)
+        countVideoLabel.snp.makeConstraints {
+            $0.center.equalTo(countVideoView.snp.center)
         }
     }
 }


### PR DESCRIPTION
### 작업 내용 설명
1. 현재 카드 분류 상태 표시 UI 제작
2. 카드 분류 상황을 받아와서 SwipableCard에 띄워 주는 기능 구현

### 관련 이슈
- #166 

### 작업의 결과물
|첫번째 카드|뒤의 카드|
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/45965405/202432731-65048901-69e6-4f38-84fc-6cee06998019.png"  width="250">|<img src="https://user-images.githubusercontent.com/45965405/202432813-15f28f64-f6e8-48c2-aec6-844294a4398f.png"  width="250">|

### 작업의 비고사항 및 한계점
- 추후 남은 카드의 수를 보여주는 방식의 디자인이 수정될 가능성 있음

Close #166 
