### PR TITLE
[#208] fix - 목록형 뷰에서 셀 선택시 나오던 에러 해결

### DIFF
--- a/OrrRock/OrrRock/Home/HomeViewController+CollectionViewExtensions.swift
+++ b/OrrRock/OrrRock/Home/HomeViewController+CollectionViewExtensions.swift
@@ -100,7 +100,9 @@ extension HomeViewController: UITableViewDelegate{
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if !isCardView {
             let vc = VideoDetailViewController()
-            vc.videoInformation = flattenSortedVideoInfoData[indexPath.row]
+            vc.videoInformation = sortedVideoInfoData[indexPath.section][indexPath.row]
+            vc.videoInformationArray = sortedVideoInfoData[indexPath.section]
+            vc.currentIndex = indexPath.row
             navigationController?.pushViewController(vc, animated: true)
         } else {
             let vc = VideoCollectionViewController()


### PR DESCRIPTION
### 작업 내용 설명
1. 목룍형 뷰에서 영상재생뷰로 넘어갈시에 나오던 에러를 해결하였습니다.


### 관련 이슈
- #208 


### 작업의 비고사항 및 한계점
- 영상재생뷰가 필요로하는 정보가 달라짐에따라 넘겨주는 정보도 수정하였습니다.

### To Reviewers
- 감사합니다.

Close #208
