### PR TITLE
[#215, #217] design - 날짜, 클라이밍장 정보 입력, 편집 UI 수정 + 기타 기능 수정

### DIFF
--- a/OrrRock/OrrRock/Upload/DateSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/DateSettingViewController.swift
@@ -15,8 +15,8 @@ class DateSettingViewController: UIViewController {
     
     let datePickerLabel : UILabel = {
         let label = UILabel()
-        label.text = "업로드할 영상의 날짜를 선택해주세요"
-        label.font = UIFont.boldSystemFont(ofSize: 17)
+        label.text = "방문한 날짜를 선택해주세요"
+        label.font = UIFont.boldSystemFont(ofSize: 22)
         label.textColor = .orrBlack
         label.backgroundColor = .orrWhite
         return label
@@ -86,7 +86,7 @@ extension DateSettingViewController {
         
         view.addSubview(datePickerLabel)
         datePickerLabel.snp.makeConstraints {
-            $0.centerX.equalTo(view)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(OrrPd.pd16.rawValue)
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(OrrPd.pd8.rawValue)
         }
         

--- a/OrrRock/OrrRock/Upload/GymSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/GymSettingViewController.swift
@@ -19,8 +19,8 @@ class GymSettingViewController: UIViewController {
     
     let gymNameLabel : UILabel = {
         let label = UILabel()
-        label.text = "해당 클라이밍장의 이름을 적어주세요"
-        label.font = UIFont.boldSystemFont(ofSize: 17)
+        label.text = "방문한 클라이밍장을 입력해주세요"
+        label.font = UIFont.boldSystemFont(ofSize: 22)
         label.textColor = .orrBlack
         label.backgroundColor = .orrWhite
         return label
@@ -195,7 +195,7 @@ extension GymSettingViewController {
     func setUpLayout() {
         view.addSubview(gymNameLabel)
         gymNameLabel.snp.makeConstraints {
-            $0.centerX.equalTo(view)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(OrrPd.pd16.rawValue)
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(OrrPd.pd8.rawValue)
         }
         
@@ -203,8 +203,7 @@ extension GymSettingViewController {
         gymTextField.snp.makeConstraints{
             $0.centerX.equalTo(view)
             $0.top.equalTo(gymNameLabel.snp.bottom).offset(OrrPd.pd40.rawValue)
-            $0.leading.equalTo(view).offset(OrrPd.pd40.rawValue)
-            $0.trailing.equalTo(view).offset(-OrrPd.pd40.rawValue)
+            $0.horizontalEdges.equalTo(view).inset(OrrPd.pd16.rawValue)
         }
         
         view.addSubview(nextButton)

--- a/OrrRock/OrrRock/Utils/CustomBackBarButtomItem.swift
+++ b/OrrRock/OrrRock/Utils/CustomBackBarButtomItem.swift
@@ -20,7 +20,7 @@ class CustomBackBarButtomItem: UIBarButtonItem {
     convenience init(target: AnyObject?, action: Selector) {
         let button = UIButton(type: .system)
         button.setImage(UIImage(systemName: "chevron.backward"), for: .normal)
-        button.setTitle("longlonglong", for: .normal)
+        button.setTitle("longlong", for: .normal)
         button.setTitleColor(.clear, for: .normal)
         button.sizeToFit()
         button.addTarget(target, action: action, for: .touchUpInside)

--- a/OrrRock/OrrRock/Utils/UnderlinedTextField.swift
+++ b/OrrRock/OrrRock/Utils/UnderlinedTextField.swift
@@ -7,9 +7,18 @@
 
 import UIKit
 
-class UnderlinedTextField: UITextField {
+import SnapKit
+
+class UnderlinedTextField: UITextField, UITextFieldDelegate {
     
     let underlineLayer = CALayer()
+    let warningLabel: UILabel = {
+        let view = UILabel()
+        view.text = "최대 20자까지 입력이 가능해요"
+        view.textColor = .orrGray400
+        view.textAlignment = .right
+        return view
+    }()
     
     /// Size the underline layer and position it as a one point line under the text field.
     func setUpUnderlineLayer() {
@@ -19,6 +28,22 @@ class UnderlinedTextField: UITextField {
         
         underlineLayer.frame = frame
         underlineLayer.backgroundColor = UIColor.orrUPBlue?.cgColor
+    }
+    
+    func setLimitWarningLabel() {
+        self.addSubview(warningLabel)
+        
+        warningLabel.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalTo(self.snp.bottom).offset(OrrPd.pd4.rawValue)
+        }
+    }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return true }
+        let newLength = text.count + string.count - range.length
+        
+        return newLength <= 20
     }
     
     // In `init?(coder:)` Add our underlineLayer as a sublayer of the view's main layer
@@ -37,6 +62,9 @@ class UnderlinedTextField: UITextField {
     // adjust the size and placement of the underline layer too
     override func layoutSubviews() {
         super.layoutSubviews()
+        
+        self.delegate = self
         setUpUnderlineLayer()
+        setLimitWarningLabel()
     }
 }

--- a/OrrRock/OrrRock/Utils/UnderlinedTextField.swift
+++ b/OrrRock/OrrRock/Utils/UnderlinedTextField.swift
@@ -15,7 +15,7 @@ class UnderlinedTextField: UITextField {
     func setUpUnderlineLayer() {
         var frame = self.bounds
         frame.origin.y = frame.size.height - 1
-        frame.size.height = 1
+        frame.size.height = 2
         
         underlineLayer.frame = frame
         underlineLayer.backgroundColor = UIColor.orrUPBlue?.cgColor

--- a/OrrRock/OrrRock/VideoDetail/DateAndGymEditViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/DateAndGymEditViewController.swift
@@ -31,8 +31,8 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
     
     private lazy var gymNameLabel : UILabel = {
         let label = UILabel()
-        label.text = "해당 암장의 이름을 적어주세요"
-        label.font = UIFont.boldSystemFont(ofSize: 17)
+        label.text = "방문한 클라이밍장을 입력해주세요"
+        label.font = UIFont.boldSystemFont(ofSize: 22)
         label.textColor = .orrBlack
         label.backgroundColor = .orrGray100
         return label
@@ -61,9 +61,9 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
     //MARK: date view 관련 components
     private lazy var datePickerLabel : UILabel = {
         let label = UILabel()
-        label.text = Date().timeToString()
-        label.font = UIFont.boldSystemFont(ofSize: 17)
-        label.textColor = .orrGray500
+        label.text = "방문한 날짜를 선택해주세요"
+        label.font = UIFont.boldSystemFont(ofSize: 22)
+        label.textColor = .orrBlack
         label.backgroundColor = .orrGray100
         return label
     }()
@@ -75,7 +75,6 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
         datePicker.datePickerMode = .date
         datePicker.timeZone = .autoupdatingCurrent
         datePicker.locale = Locale(identifier:"ko_KR")
-        datePicker.addTarget(self, action: #selector(handleDatePicker(_:)), for: .valueChanged)
         datePicker.backgroundColor = .orrGray100
         datePicker.maximumDate = Date()
         return datePicker
@@ -177,8 +176,8 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
         
         dateContentView.addSubview(datePickerLabel)
         datePickerLabel.snp.makeConstraints {
-            $0.centerX.equalTo(dateContentView)
-            $0.top.equalTo(dateContentView.snp.top).offset(OrrPd.pd24.rawValue)
+            $0.horizontalEdges.equalTo(dateContentView).inset(OrrPd.pd16.rawValue)
+            $0.top.equalTo(dateContentView.snp.top).offset(OrrPd.pd72.rawValue)
         }
         
         dateContentView.addSubview(datePicker)
@@ -208,16 +207,15 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
         
         gymContentView.addSubview(gymNameLabel)
         gymNameLabel.snp.makeConstraints {
-            $0.centerX.equalTo(dateContentView)
-            $0.top.equalTo(dateContentView.snp.top).offset(OrrPd.pd24.rawValue)
+            $0.horizontalEdges.equalTo(dateContentView).inset(OrrPd.pd16.rawValue)
+            $0.top.equalTo(dateContentView.snp.top).offset(OrrPd.pd72.rawValue)
         }
         
         gymContentView.addSubview(gymTextField)
         gymTextField.snp.makeConstraints{
             $0.centerX.equalTo(gymContentView)
-            $0.top.equalTo(gymNameLabel.snp.bottom).offset(OrrPd.pd16.rawValue)
-            $0.leading.equalTo(gymContentView).offset(OrrPd.pd40.rawValue)
-            $0.trailing.equalTo(gymContentView).offset(-OrrPd.pd40.rawValue)
+            $0.top.equalTo(gymNameLabel.snp.bottom).offset(OrrPd.pd36.rawValue)
+            $0.horizontalEdges.equalTo(gymContentView).inset(OrrPd.pd16.rawValue)
         }
         
         gymContentView.addSubview(saveButton)
@@ -256,7 +254,6 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
         datePicker.date = videoInformation.gymVisitDate
         gymTextField.text = videoInformation.gymName
         gymTextField.placeholder = videoInformation.gymName
-        datePickerLabel.text = videoInformation.gymVisitDate.timeToString()
         selectDate = videoInformation.gymVisitDate
         selectGymName = videoInformation.gymName
     }
@@ -291,12 +288,6 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
 }
 
 extension DateAndGymEditViewController {
-    
-    @objc
-    private func handleDatePicker(_ sender: UIDatePicker) {
-        datePickerLabel.text = sender.date.timeToString()
-        datePickerLabel.textColor = .black
-    }
     
     @objc
     private func pressNextButton(_ sender: UIButton) {

--- a/OrrRock/OrrRock/VideoDetail/DateAndGymEditViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/DateAndGymEditViewController.swift
@@ -34,7 +34,6 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
         label.text = "방문한 클라이밍장을 입력해주세요"
         label.font = UIFont.boldSystemFont(ofSize: 22)
         label.textColor = .orrBlack
-        label.backgroundColor = .orrGray100
         return label
     }()
     
@@ -64,7 +63,6 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
         label.text = "방문한 날짜를 선택해주세요"
         label.font = UIFont.boldSystemFont(ofSize: 22)
         label.textColor = .orrBlack
-        label.backgroundColor = .orrGray100
         return label
     }()
     
@@ -75,7 +73,6 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
         datePicker.datePickerMode = .date
         datePicker.timeZone = .autoupdatingCurrent
         datePicker.locale = Locale(identifier:"ko_KR")
-        datePicker.backgroundColor = .orrGray100
         datePicker.maximumDate = Date()
         return datePicker
     }()
@@ -100,7 +97,7 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
     
     private lazy var dateTopView : UIView = {
         let view = UIView()
-        view.backgroundColor = .orrWhite
+        view.backgroundColor = .orrGray100
         
         view.addSubview(titleLabel)
         titleLabel.snp.makeConstraints {
@@ -156,7 +153,7 @@ final class DateAndGymEditViewController: UIViewController , UISheetPresentation
     }
     
     private func setUpLayout(){
-        view.backgroundColor = .orrGray100
+        view.backgroundColor = .orrWhite
         self.navigationController?.isToolbarHidden = false
         
         view.addSubview(dateTopView)


### PR DESCRIPTION
### 작업 내용 설명
1. 날짜 선택 뷰 UI 수정
2. 클라이밍장 명 입력 뷰 UI 수정
3. 클라이밍장명 20자 길이 제한 기능 구현
4. VideoCollectionView 내 타이틀이 정중앙을 벗어나지 않도록 개선

### 관련 이슈
- #215 #217 

### 작업의 결과물
|날짜 입력 UI|클라이밍장 명 입력 UI + 20자 제한 UI|
|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/202916659-e7704565-776d-41c8-b421-cd2d26989473.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/202916585-f690d7fb-43dc-4cb2-ab91-9457afc1703e.png">|

VideoCollectionView 내 타이틀이 길어지더라도 타이틀이 제 자리를 지키도록 개선
|변경 전|변경 후|
|---|---|
|![](https://user-images.githubusercontent.com/39216546/202905834-9785c83f-0be3-4929-8f44-6f42ce7b1579.png)|<img width="600" alt="image" src="https://user-images.githubusercontent.com/39216546/202922974-12c86b5a-832b-476d-bc2c-1f4c2bc5f9b7.png">|


### 작업의 비고사항 및 한계점
- UnderlinedTextField 모듈 자체에 20자 제한 레이블을 달아두어, UnderlinedTextField를 사용할 때에는 해당 레이블이 자동으로 하단에 붙도록 만들어두었습니다.
- 이후에, UnderlinedTextField가 클라이밍장 명을 입력받는 용도가 아닌 다른 용도로 재활용이 되어야 하는 경우가 생기면, 이에 따른 처리를 해주도록 하겠습니다.

### To Reviewers
- 사랑해요

Close #215 #217 
