### PR TITLE
[#234] hotfix - Release 버전 관리를 위한 UINavigationViewController root뷰 수정

### DIFF
--- a/OrrRock/OrrRock/SceneDelegate.swift
+++ b/OrrRock/OrrRock/SceneDelegate.swift
@@ -19,7 +19,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window?.backgroundColor = .white
         
-        window?.rootViewController = UINavigationController(rootViewController: MainViewController())
+//        window?.rootViewController = UINavigationController(rootViewController: MainViewController())
+        window?.rootViewController = UINavigationController(rootViewController: HomeViewController())
         window?.makeKeyAndVisible()
     }
     


### PR DESCRIPTION
### 작업 내용 설명
1. 기존 MainViewController 코드부는 주석처리
2. 1.0.3버전을 위하여 일시적으로 rootVC HomeViewController로 수정

### 관련 이슈
- #234

### 작업의 결과물
```
// SceneDelegate.swift
//        window?.rootViewController = UINavigationController(rootViewController: MainViewController())
        window?.rootViewController = UINavigationController(rootViewController: HomeViewController())
```

### To Reviewers
- ♥️

Close #234
