### PR TITLE
[#254] fix - 레벨 수정 뷰 기기대응

### DIFF
--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -31,10 +31,10 @@
 		342C457029018D5C0037D9E7 /* HomeCollectionViewFooterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 342C456F29018D5C0037D9E7 /* HomeCollectionViewFooterCell.swift */; };
 		34793F9F29251E4B00B74110 /* BetterSegmentedControl in Frameworks */ = {isa = PBXBuildFile; productRef = 34793F9E29251E4B00B74110 /* BetterSegmentedControl */; };
 		34793FA329262A8800B74110 /* CustomBackBarButtomItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34793FA229262A8800B74110 /* CustomBackBarButtomItem.swift */; };
-		34E11EC9292D2C5100787316 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E11EC8292D2C5100787316 /* UIImage+.swift */; };
 		3495AEF72929192000006469 /* CalendarComponent+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3495AEF62929192000006469 /* CalendarComponent+.swift */; };
 		34E11EC3292BEDCF00787316 /* FirstDateSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E11EC2292BEDCF00787316 /* FirstDateSettingViewController.swift */; };
 		34E11EC5292BFF2700787316 /* ExportCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E11EC4292BFF2700787316 /* ExportCardView.swift */; };
+		34E11EC9292D2C5100787316 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E11EC8292D2C5100787316 /* UIImage+.swift */; };
 		34E76F462924D33E00EBB92D /* HomeTableViewFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E76F452924D33E00EBB92D /* HomeTableViewFooter.swift */; };
 		34EC54582924C93B00EE558E /* HomeTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EC54572924C93B00EE558E /* HomeTableViewHeader.swift */; };
 		3A15AC7729071DD90058512F /* OrderOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A15AC7629071DD90058512F /* OrderOption.swift */; };
@@ -131,10 +131,10 @@
 		342C456D290125260037D9E7 /* HomeTableViewListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTableViewListCell.swift; sourceTree = "<group>"; };
 		342C456F29018D5C0037D9E7 /* HomeCollectionViewFooterCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewFooterCell.swift; sourceTree = "<group>"; };
 		34793FA229262A8800B74110 /* CustomBackBarButtomItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomBackBarButtomItem.swift; sourceTree = "<group>"; };
-		34E11EC8292D2C5100787316 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		3495AEF62929192000006469 /* CalendarComponent+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CalendarComponent+.swift"; sourceTree = "<group>"; };
 		34E11EC2292BEDCF00787316 /* FirstDateSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstDateSettingViewController.swift; sourceTree = "<group>"; };
 		34E11EC4292BFF2700787316 /* ExportCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportCardView.swift; sourceTree = "<group>"; };
+		34E11EC8292D2C5100787316 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		34E76F452924D33E00EBB92D /* HomeTableViewFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTableViewFooter.swift; sourceTree = "<group>"; };
 		34EC54572924C93B00EE558E /* HomeTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeTableViewHeader.swift; sourceTree = "<group>"; };
 		3A15AC7629071DD90058512F /* OrderOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderOption.swift; sourceTree = "<group>"; };
@@ -413,9 +413,8 @@
 			children = (
 				78F93ED22906EFC500F3D9F3 /* GymEditViewController.swift */,
 				34172EAE292AAD3E009DAAB8 /* DateEditViewController.swift */,
-				341418BC2923A6FF0033D851 /* GymEditViewController+TableViewExtensions.swift */,
-				78FEE88929261641007B67BD /* VideoCollection */,
 				78F93ED6290743DF00F3D9F3 /* LevelAndPFEditViewController.swift */,
+				78FEE88929261641007B67BD /* VideoCollection */,
 				78FEE89D292976FA007B67BD /* VideoDetailViewController */,
 				3AEB3D61291C03A900A989FF /* UIComponent */,
 			);

--- a/OrrRock/OrrRock/VideoDetail/LevelAndPFEditViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/LevelAndPFEditViewController.swift
@@ -155,19 +155,19 @@ extension LevelAndPFEditViewController {
         levelContentView.addSubview(LevelLabel)
         LevelLabel.snp.makeConstraints {
             $0.centerX.equalTo(levelContentView)
-            $0.top.equalTo(levelContentView.snp.top).offset(OrrPd.pd40.rawValue)
+            $0.top.equalTo(levelContentView.snp.top).offset(UIScreen.main.bounds.height<700 ? OrrPd.pd24.rawValue : OrrPd.pd40.rawValue)
         }
         
         levelContentView.addSubview(pickerView)
         pickerView.snp.makeConstraints {
             $0.leading.equalTo(levelContentView).offset(47)
             $0.trailing.equalTo(levelContentView).offset(-47)
-            $0.top.equalTo(LevelLabel.snp.bottom).offset(OrrPd.pd24.rawValue)
+            $0.top.equalTo(LevelLabel.snp.bottom).offset(UIScreen.main.bounds.height<700 ? OrrPd.pd16.rawValue : OrrPd.pd24.rawValue)
         }
         
         levelContentView.addSubview(successLabel)
         successLabel.snp.makeConstraints {
-            $0.top.equalTo(pickerView.snp.bottom).offset(OrrPd.pd72.rawValue)
+            $0.top.equalTo(pickerView.snp.bottom).offset(UIScreen.main.bounds.height<700 ? OrrPd.pd24.rawValue : OrrPd.pd72.rawValue)
             $0.centerX.equalToSuperview()
         }
         


### PR DESCRIPTION
### 작업 내용 설명
1. 아이폰8같은 작은 화면에도 잘 보이게 수정하였습니다.


### 관련 이슈
- #254

### 작업의 결과물
| 아이폰 8| 아이폰14 프로맥스 |
|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/72395020/203487539-1a7538f0-34ef-403a-be99-7a7d9699dd64.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/72395020/203487625-5c1d55b5-40bb-45e2-b891-2aba14a0c4a6.png">|

### 작업의 비고사항 및 한계점
- 빠른 출시를 위하여 테이프로 구멍을 막은 느낌이 있지만 완료되었습니다!
- enum이나 패딩뷰를 사용하여 기기대응을 진행하는 방법도 있을것 같습니다.



### To Reviewers
- 감사합니다

Close #254 
