### PR TITLE
[#261] hotfix - Release 버전 관리를 위한 MainViewController TabBarItem 수정

### DIFF
--- a/OrrRock/OrrRock/MainViewController.swift
+++ b/OrrRock/OrrRock/MainViewController.swift
@@ -16,22 +16,22 @@ class MainViewController: UITabBarController {
         // TODO: 새로운 뷰 작업시 이곳에 ViewController 연결하기
         let myActivityViewController = MyActivityViewController()
         let homeViewController = HomeViewController()
-        let routeFindingController = UIViewController()
+//        let routeFindingController = UIViewController()
         
         // Tab Bar의 아이템 생성
         let myActivityItem = UITabBarItem(title: "내 활동", image: UIImage(named: "tabbar mypage icon"), tag: 0)
         let homeItem = UITabBarItem(title: "기록", image: UIImage(named: "tabbar home icon"), tag: 1)
-        let routeFindingItem = UITabBarItem(title: "루트파인딩", image: UIImage(named: "tabbar routefinding icon"), tag: 2)
+//        let routeFindingItem = UITabBarItem(title: "루트파인딩", image: UIImage(named: "tabbar routefinding icon"), tag: 2)
         
         // 각 뷰 컨트롤러에 아이템 할당
         myActivityViewController.tabBarItem = myActivityItem
         homeViewController.tabBarItem = homeItem
-        routeFindingController.tabBarItem = routeFindingItem
+//        routeFindingController.tabBarItem = routeFindingItem
         
         // 생성한 ViewController들을 Tab Bar에 할당
         self.setViewControllers([myActivityViewController,
                                    homeViewController,
-                                   routeFindingController], animated: true)
+                                   /*routeFindingController*/], animated: true)
 
         // Tab Bar 아이템의 색상 설정
         self.tabBar.tintColor = .orrUPBlue!


### PR DESCRIPTION
### 작업 내용 설명
1. 기존 MainViewController에 존재하던 routeFinding과 관련된 항목 주석 처리
2. 1.1.0 버전을 위하여 일시적으로 rootVC tabBarItem의 수를 2개로 수정

### 관련 이슈
- #261

### 작업의 결과물
```
// MainViewController.swift
let myActivityViewController = MyActivityViewController()
        let homeViewController = HomeViewController()
//        let routeFindingController = UIViewController()
        
        // Tab Bar의 아이템 생성
        let myActivityItem = UITabBarItem(title: "내 활동", image: UIImage(named: "tabbar mypage icon"), tag: 0)
        let homeItem = UITabBarItem(title: "기록", image: UIImage(named: "tabbar home icon"), tag: 1)
//        let routeFindingItem = UITabBarItem(title: "루트파인딩", image: UIImage(named: "tabbar routefinding icon"), tag: 2)
        
        // 각 뷰 컨트롤러에 아이템 할당
        myActivityViewController.tabBarItem = myActivityItem
        homeViewController.tabBarItem = homeItem
//        routeFindingController.tabBarItem = routeFindingItem
        
        // 생성한 ViewController들을 Tab Bar에 할당
        self.setViewControllers([myActivityViewController,
                                   homeViewController,
                                   /*routeFindingController*/], animated: true)
```

### To Reviewers
- ♥️

Close #261 