### PR TITLE
[#264] fix  - 컬러피커뷰의 선택 상태 개선을 했습니다.

### DIFF
--- a/OrrRock/OrrRock/Utils/ColorPickerView.swift
+++ b/OrrRock/OrrRock/Utils/ColorPickerView.swift
@@ -165,7 +165,7 @@ extension ColorPickerView : UIPickerViewDelegate,UIPickerViewDataSource{
         }
         
         let selectLabel = selectView.subviews[0] as! UILabel
-        selectLabel.backgroundColor = .white
+        selectLabel.backgroundColor = selectLabel.subviews[0].backgroundColor
         return pickerRow
     }
     

--- a/OrrRock/OrrRock/Utils/ColorPickerView.swift
+++ b/OrrRock/OrrRock/Utils/ColorPickerView.swift
@@ -93,12 +93,7 @@ extension ColorPickerView : UIPickerViewDelegate,UIPickerViewDataSource{
         }
 
         let selectLabel = selectView.subviews[0] as! UILabel
-        selectLabel.backgroundColor = .orrWhite
-        selectLabel.layer.shadowColor = UIColor.orrBlack?.cgColor
-        selectLabel.layer.shadowOpacity = 1.0
-        selectLabel.layer.shadowOffset = CGSize.zero
-        selectLabel.layer.shadowRadius = 10
-
+        selectLabel.backgroundColor = selectLabel.subviews[0].backgroundColor
 
         if let beforeView = pickerView.view(forRow: row - 1, forComponent: component) {
             let beforeLabel = beforeView.subviews[0] as! UILabel


### PR DESCRIPTION
### 작업 내용 설명
1. 기존 선택된 상태의 변화가 흰색 테두리가 생기는 것이 가시성이 좋지 않아
2. 선택된 색상의 테두리가 생기는것으로 수정 했습니다.


### 관련 이슈
- #264 

### 작업의 결과물
#### 변경전
https://user-images.githubusercontent.com/103024840/203731008-1e7be89a-9739-45f4-b6de-ab1c32daa595.mov


#### 변경후
https://user-images.githubusercontent.com/103024840/203730728-9707f3b9-67e0-4ee0-9bb1-4fd030c84dfe.mov


### 작업의 비고사항 및 한계점
- 선택된 레이블이 넘어갈때 살짝 어색해 보이는 부분은 개선 방법은 찾고 있으나 기존 피커 커스텀을 해야 하는 부분이라
- 지금 당장 수정은 어려울듯 합니다.
- 하지만 그래도 저에게 한계란 없습니다.

### To Reviewers
- 리뷰어에게 중점적으로 살펴봐줬으면 하는 내용

Close #264 
