### PR TITLE
[#241] fix 앱의 전체적인 부분에서 뒤로가기 버튼 및 뒤로가기 제스쳐 수정

### DIFF
--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -865,7 +865,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = ML59XN7A6B;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -881,7 +881,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -900,7 +900,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = ML59XN7A6B;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -916,7 +916,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		3AEB3D5D291C003D00A989FF /* VideoCollectionViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AEB3D5C291C003D00A989FF /* VideoCollectionViewMode.swift */; };
 		700AC6212926A1DA003DF5AF /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700AC6202926A1DA003DF5AF /* UIImageView+.swift */; };
 		704BAB5E292834DB004D987A /* NewLevelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 704BAB5D292834DB004D987A /* NewLevelPickerView.swift */; };
+		705C19C929309AB300C975D5 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 705C19C829309AB300C975D5 /* UINavigationController+.swift */; };
 		707B2CAE28FFF7090062C958 /* NVActivityIndicatorView in Frameworks */ = {isa = PBXBuildFile; productRef = 707B2CAD28FFF7090062C958 /* NVActivityIndicatorView */; };
 		707B2CB829012BFE0062C958 /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707B2CB729012BFE0062C958 /* Color+.swift */; };
 		707B2CBA2901382A0062C958 /* OrrPd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 707B2CB92901382A0062C958 /* OrrPd.swift */; };
@@ -160,6 +161,7 @@
 		3AEB3D5C291C003D00A989FF /* VideoCollectionViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoCollectionViewMode.swift; sourceTree = "<group>"; };
 		700AC6202926A1DA003DF5AF /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 		704BAB5D292834DB004D987A /* NewLevelPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewLevelPickerView.swift; sourceTree = "<group>"; };
+		705C19C829309AB300C975D5 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		707B2CB729012BFE0062C958 /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		707B2CB92901382A0062C958 /* OrrPd.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrrPd.swift; sourceTree = "<group>"; };
 		7085BA29292D2F08004FD734 /* ColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerView.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 				700AC6202926A1DA003DF5AF /* UIImageView+.swift */,
 				34E11EC8292D2C5100787316 /* UIImage+.swift */,
 				70AE8137292CA24500B4DB3F /* Font+.swift */,
+				705C19C829309AB300C975D5 /* UINavigationController+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -681,6 +684,7 @@
 				341418B42922974D0033D851 /* VisitedClimbingGym+CoreDataClass.swift in Sources */,
 				78A0354C290131E100FF1913 /* VideoCollectionViewController.swift in Sources */,
 				342508A329001780000653D9 /* HomeViewController.swift in Sources */,
+				705C19C929309AB300C975D5 /* UINavigationController+.swift in Sources */,
 				342508A52900196B000653D9 /* HomeViewController+CollectionViewExtensions.swift in Sources */,
 				78FEE88F2926A23B007B67BD /* VideoPlayViewController.swift in Sources */,
 				FBA5DBFD291AE32A00422A17 /* ButtonClickEffect.swift in Sources */,
@@ -861,7 +865,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = ML59XN7A6B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -877,7 +881,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -896,7 +900,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = ML59XN7A6B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -912,7 +916,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/OrrRock/OrrRock/Extensions/UINavigationController+.swift
+++ b/OrrRock/OrrRock/Extensions/UINavigationController+.swift
@@ -12,9 +12,7 @@ extension UINavigationController {
 
     func setExpansionBackbuttonArea() {
         let backButton: UIBarButtonItem = UIBarButtonItem()
-        backButton.title = "                             "
-        backButton.tintColor = .red
-        
+        backButton.title = "                             "        
         self.navigationBar.topItem?.backBarButtonItem = backButton
     }
     

--- a/OrrRock/OrrRock/Extensions/UINavigationController+.swift
+++ b/OrrRock/OrrRock/Extensions/UINavigationController+.swift
@@ -1,0 +1,21 @@
+//
+//  UINavigationController+.swift
+//  OrrRock
+//
+//  Created by Ruyha on 2022/11/25.
+//
+
+import UIKit
+
+extension UINavigationController {
+    
+
+    func setExpansionBackbuttonArea() {
+        let backButton: UIBarButtonItem = UIBarButtonItem()
+        backButton.title = "                             "
+        backButton.tintColor = .red
+        
+        self.navigationBar.topItem?.backBarButtonItem = backButton
+    }
+    
+}

--- a/OrrRock/OrrRock/Extensions/UINavigationController+.swift
+++ b/OrrRock/OrrRock/Extensions/UINavigationController+.swift
@@ -9,10 +9,9 @@ import UIKit
 
 extension UINavigationController {
     
-
     func setExpansionBackbuttonArea() {
         let backButton: UIBarButtonItem = UIBarButtonItem()
-        backButton.title = "기기기기기기기긱"//"                             "        
+        backButton.title = "                             "
         self.navigationBar.topItem?.backBarButtonItem = backButton
     }
     

--- a/OrrRock/OrrRock/Extensions/UINavigationController+.swift
+++ b/OrrRock/OrrRock/Extensions/UINavigationController+.swift
@@ -12,7 +12,7 @@ extension UINavigationController {
 
     func setExpansionBackbuttonArea() {
         let backButton: UIBarButtonItem = UIBarButtonItem()
-        backButton.title = "                             "        
+        backButton.title = "기기기기기기기긱"//"                             "        
         self.navigationBar.topItem?.backBarButtonItem = backButton
     }
     

--- a/OrrRock/OrrRock/MyActivity/MyActivityViewController.swift
+++ b/OrrRock/OrrRock/MyActivity/MyActivityViewController.swift
@@ -149,7 +149,6 @@ class MyActivityViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.backgroundColor = .clear
         self.navigationController?.isNavigationBarHidden = true
         
         setUpData()

--- a/OrrRock/OrrRock/SwipeOnboarding/SwipeOnboardingViewController.swift
+++ b/OrrRock/OrrRock/SwipeOnboarding/SwipeOnboardingViewController.swift
@@ -19,7 +19,6 @@ class SwipeOnboardingViewController: UIPageViewController {
     var currentIndex: Int?
     var pendingIndex: Int?
     var index = 0
-    //MARK: Ruyha Test
     var firstView : SwipeOnboardingFirstViewController = {
         let vc = SwipeOnboardingFirstViewController()
         return vc
@@ -57,7 +56,6 @@ class SwipeOnboardingViewController: UIPageViewController {
         fifthView.delegate = self
         
         setDelegate()
-        //MARK: Ruyha 스크롤링을 막음
         self.isPagingEnabled = false
 
         }

--- a/OrrRock/OrrRock/Upload/DateSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/DateSettingViewController.swift
@@ -45,15 +45,12 @@ class DateSettingViewController: UIViewController {
         btn.setTitleColor(.white, for: .normal)
         return btn
     }()
-    
+
     //MARK: 생명주기 함수 모음
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .orrWhite
-        
-        self.navigationController?.navigationBar.topItem?.title = ""
-        navigationItem.leftBarButtonItem = CustomBackBarButtomItem(target: self, action: #selector(didBackButtonClicked))
-        navigationItem.leftBarButtonItem?.tintColor = .orrUPBlue
+        self.navigationController?.setExpansionBackbuttonArea()
         
         setUpLayout()
     }
@@ -74,9 +71,6 @@ extension DateSettingViewController {
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
     
-    @objc func didBackButtonClicked(_ sender: UIBarButtonItem) {
-        self.navigationController?.popToRootViewController(animated: true)
-    }
 }
 
 //MARK: 오토레이아웃 설정 영역

--- a/OrrRock/OrrRock/Upload/GymSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/GymSettingViewController.swift
@@ -69,9 +69,7 @@ class GymSettingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .orrWhite
-        self.navigationController?.navigationBar.topItem?.title = ""
-        navigationItem.leftBarButtonItem = CustomBackBarButtomItem(target: self, action: #selector(didBackButtonClicked))
-        navigationItem.leftBarButtonItem?.tintColor = .orrUPBlue
+        self.navigationController?.setExpansionBackbuttonArea()
         
         setUpData()
         setUpLayout()
@@ -79,7 +77,12 @@ class GymSettingViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
+//        gymTextField.becomeFirstResponder()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
         gymTextField.becomeFirstResponder()
+
     }
     
 }
@@ -149,9 +152,6 @@ extension GymSettingViewController {
         }
     }
     
-    @objc func didBackButtonClicked(_ sender: UIBarButtonItem) {
-        self.navigationController?.popToRootViewController(animated: true)
-    }
     
     final private func authSettingOpen(alertType: AuthSettingAlert) {
         let message = alertType.rawValue

--- a/OrrRock/OrrRock/Upload/GymSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/GymSettingViewController.swift
@@ -76,10 +76,6 @@ class GymSettingViewController: UIViewController {
         setUITableViewDelegate()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-//        gymTextField.becomeFirstResponder()
-    }
-    
     override func viewDidAppear(_ animated: Bool) {
         gymTextField.becomeFirstResponder()
 

--- a/OrrRock/OrrRock/Upload/GymSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/GymSettingViewController.swift
@@ -70,7 +70,7 @@ class GymSettingViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .orrWhite
         self.navigationController?.setExpansionBackbuttonArea()
-        
+
         setUpData()
         setUpLayout()
         setUITableViewDelegate()

--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -166,7 +166,7 @@ final class LevelAndPFSettingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         if !UserDefaults.standard.bool(forKey: "SwipeOnboardingClear"){
             let nextVC = SwipeOnboardingViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
             nextVC.modalPresentationStyle = .fullScreen
@@ -175,9 +175,8 @@ final class LevelAndPFSettingViewController: UIViewController {
         
         view.backgroundColor = .orrWhite
         
-        navigationItem.leftBarButtonItem = CustomBackBarButtomItem(target: self, action: #selector(backButtonClicked))
-        navigationItem.leftBarButtonItem?.tintColor = .orrUPBlue
-        
+        self.navigationController?.setExpansionBackbuttonArea()
+
         // card UI
         setUpLayout()
         
@@ -554,11 +553,6 @@ private extension LevelAndPFSettingViewController {
                 
             }
         }
-    }
-    
-    @objc
-    func backButtonClicked() {
-        self.navigationController?.popViewController(animated: true)
     }
     
     // 모든 카드를 스와이핑 했을 때 호출되는 메서드

--- a/OrrRock/OrrRock/Utils/CustomBackBarButtomItem.swift
+++ b/OrrRock/OrrRock/Utils/CustomBackBarButtomItem.swift
@@ -26,5 +26,7 @@ class CustomBackBarButtomItem: UIBarButtonItem {
         button.addTarget(target, action: action, for: .touchUpInside)
 
         self.init(customView: button)
+        
+        
     }
 }

--- a/OrrRock/OrrRock/VideoDetail/UIComponent/View/VideoInfoView.swift
+++ b/OrrRock/OrrRock/VideoDetail/UIComponent/View/VideoInfoView.swift
@@ -19,8 +19,18 @@ final class VideoInfoView: UIView {
         let view = UITextView()
         view.backgroundColor = .orrWhite
         view.font = .systemFont(ofSize: 17.0, weight: .semibold)
+        view.keyboardType = .default
+        view.returnKeyType = UIReturnKeyType.done
         return view
     }()
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" {
+            textView.resignFirstResponder()
+            return false
+        }
+        return true
+    }
     
     // 날짜 관련 View
     private lazy var dateView: UIView = {

--- a/OrrRock/OrrRock/VideoDetail/VideoCollection/VideoCollectionViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/VideoCollection/VideoCollectionViewController.swift
@@ -31,17 +31,14 @@ class VideoCollectionViewController: UIViewController {
                 let indexCountLabel = UILabel()
                 indexCountLabel.text = "항목 선택"
                 toolbarText.customView = indexCountLabel
-//                navigationItem.leftBarButtonItem = backBarButton
                 self.navigationController?.setExpansionBackbuttonArea()
 
                 videoCollectionView.allowsMultipleSelection = false
-//                navigationController?.interactivePopGestureRecognizer?.isEnabled = true
                 self.navigationController?.setToolbarHidden(true, animated: true)
             case .select:
                 selectBarButton.title = "취소"
                 navigationItem.leftBarButtonItem = selectAllButton
                 videoCollectionView.allowsMultipleSelection = true
-//                navigationController?.interactivePopGestureRecognizer?.isEnabled = false
                 self.navigationController?.setToolbarHidden(false, animated: true)
             }
         }
@@ -91,10 +88,6 @@ class VideoCollectionViewController: UIViewController {
         return barButtonItem
     }()
     
-//    lazy var backBarButton: UIBarButtonItem = {
-//        let barButtonItem = CustomBackBarButtomItem(target: self, action: #selector(didBackButtonClicked(_:)))
-//        return barButtonItem
-//    }()
     
     lazy var deleteBarButton: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: #selector(didDeleteActionSheetClicked(_:)))

--- a/OrrRock/OrrRock/VideoDetail/VideoCollection/VideoCollectionViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/VideoCollection/VideoCollectionViewController.swift
@@ -31,15 +31,17 @@ class VideoCollectionViewController: UIViewController {
                 let indexCountLabel = UILabel()
                 indexCountLabel.text = "항목 선택"
                 toolbarText.customView = indexCountLabel
-                navigationItem.leftBarButtonItem = backBarButton
+//                navigationItem.leftBarButtonItem = backBarButton
+                self.navigationController?.setExpansionBackbuttonArea()
+
                 videoCollectionView.allowsMultipleSelection = false
-                navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+//                navigationController?.interactivePopGestureRecognizer?.isEnabled = true
                 self.navigationController?.setToolbarHidden(true, animated: true)
             case .select:
                 selectBarButton.title = "취소"
                 navigationItem.leftBarButtonItem = selectAllButton
                 videoCollectionView.allowsMultipleSelection = true
-                navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+//                navigationController?.interactivePopGestureRecognizer?.isEnabled = false
                 self.navigationController?.setToolbarHidden(false, animated: true)
             }
         }
@@ -89,10 +91,10 @@ class VideoCollectionViewController: UIViewController {
         return barButtonItem
     }()
     
-    lazy var backBarButton: UIBarButtonItem = {
-        let barButtonItem = CustomBackBarButtomItem(target: self, action: #selector(didBackButtonClicked(_:)))
-        return barButtonItem
-    }()
+//    lazy var backBarButton: UIBarButtonItem = {
+//        let barButtonItem = CustomBackBarButtomItem(target: self, action: #selector(didBackButtonClicked(_:)))
+//        return barButtonItem
+//    }()
     
     lazy var deleteBarButton: UIBarButtonItem = {
         let barButtonItem = UIBarButtonItem(barButtonSystemItem: .trash, target: self, action: #selector(didDeleteActionSheetClicked(_:)))
@@ -182,7 +184,9 @@ class VideoCollectionViewController: UIViewController {
         }
         self.toolbarItems = bottomBatItems
         navigationItem.rightBarButtonItem = selectBarButton
-        navigationItem.leftBarButtonItem = backBarButton
+//        navigationItem.leftBarButtonItem = backBarButton
+        self.navigationController?.setExpansionBackbuttonArea()
+
         firstContentOffset = Float(videoCollectionView.contentOffset.y)
     }
     
@@ -217,7 +221,9 @@ class VideoCollectionViewController: UIViewController {
         selectBarButton.title = "편집"
         let indexCountLabel = UILabel()
         indexCountLabel.text = "항목 선택"
-        navigationItem.leftBarButtonItem = backBarButton
+//        navigationItem.leftBarButtonItem = backBarButton
+        self.navigationController?.setExpansionBackbuttonArea()
+
         self.navigationController?.setToolbarHidden(true, animated: true)
         
         videoCollectionView.allowsMultipleSelection = false

--- a/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
@@ -42,14 +42,13 @@ class VideoDetailViewController: UIViewController {
     var soundButton: UIBarButtonItem!
     var playButton: UIBarButtonItem!
     var favoriteButton: UIBarButtonItem!
-    private var goBackButton: UIBarButtonItem!
     private var flexibleSpace: UIBarButtonItem!
-    private var cancelButton: UIBarButtonItem!
     private var completeButton: UIBarButtonItem!
     
     lazy var topSafeAreaView: UIView = {
         let view = UIView()
         view.backgroundColor = .orrWhite
+        
         return view
     }()
     
@@ -75,8 +74,8 @@ class VideoDetailViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(false)
         self.navigationController?.isToolbarHidden = false
-        self.navigationController?.hidesBarsOnTap = true
         self.navigationController?.isNavigationBarHidden = false
+        
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -84,26 +83,23 @@ class VideoDetailViewController: UIViewController {
         self.navigationController?.isNavigationBarHidden = false
         self.navigationController?.navigationBar.layer.opacity = 1
         self.topSafeAreaView.layer.opacity = 1
+        print("ruyha/색 살림")
+
     }
     
     // 네비게이션바 세팅 함수
     func setNavigationBar() {
         // 네비게이션바 버튼 아이템 생성
         flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
-        goBackButton = CustomBackBarButtomItem(target: self, action: #selector(goBackAction))
         favoriteButton = UIBarButtonItem(image: UIImage(systemName: videoInformation.isFavorite ? "heart.fill" : "heart"), style: .plain, target: self, action: #selector(favoriteAction))
-        cancelButton = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(cancelAction))
         completeButton = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(completeAction))
-        
+        self.navigationController?.setExpansionBackbuttonArea()
+
         // 네비게이션바 띄워주고 탭 되었을 때 숨기기
         navigationController?.isToolbarHidden = false
-        navigationController?.hidesBarsOnTap = true
         
         // 배경, 네비게이션바, 툴바 색 지정
         self.view.backgroundColor = .orrWhite
-//        navigationController?.toolbar.backgroundColor = .orrWhite
-        navigationItem.leftBarButtonItem = goBackButton
-       
         
         // 툴바 버튼 아이템 생성
         exportButton = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"), style: .plain, target: self, action: #selector(exportAction))
@@ -132,13 +128,13 @@ class VideoDetailViewController: UIViewController {
     @objc func showInfo() {
         isShowInfo.toggle()
         infoButton.image = UIImage(systemName: isShowInfo ? "info.circle.fill" : "info.circle")
-        navigationController?.hidesBarsOnTap = !isShowInfo
+//        navigationController?.hidesBarsOnTap = !isShowInfo
         feedbackText = videoInfoView.feedbackTextView.text!
         if isShowInfo {
             UIView.animate(withDuration: 0.2, animations: {
                 self.videoInfoView.transform = CGAffineTransform(translationX: 0, y: -430)
                 self.videoDetailPageViewController.view.transform = CGAffineTransform(translationX: 0, y: -430)
-                self.navigationController?.navigationBar.layer.opacity = 0
+                self.navigationController?.isNavigationBarHidden = true
                 self.topSafeAreaView.layer.opacity = 0
                 self.navigationController?.isToolbarHidden = false
                 self.bottomSafeAreaView.layer.opacity = 1.0
@@ -147,7 +143,7 @@ class VideoDetailViewController: UIViewController {
             UIView.animate(withDuration: 0.2, animations: {
                 self.videoInfoView.transform = CGAffineTransform(translationX: 0, y: 0)
                 self.videoDetailPageViewController.view.transform = CGAffineTransform(translationX: 0, y: 0)
-                self.navigationController?.navigationBar.layer.opacity = 1
+                self.navigationController?.isNavigationBarHidden = false
                 self.topSafeAreaView.layer.opacity = 1
             })
         }
@@ -158,7 +154,6 @@ class VideoDetailViewController: UIViewController {
         self.navigationController?.popViewController(animated: true)
         navigationController?.isNavigationBarHidden = false
         navigationController?.isToolbarHidden = true
-        navigationController?.hidesBarsOnTap = false
     }
     
     // 삭제 버튼을 눌렀을 때 로직
@@ -250,26 +245,16 @@ extension VideoDetailViewController {
     @objc func showKeyboard(notification: NSNotification) {
         if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             isShowKeyboard.toggle()
-            self.navigationController?.navigationBar.layer.opacity = 1
-            self.topSafeAreaView.layer.opacity = 1
-            // 키보드의 유무에 따라 버튼 옵션 변경
-            navigationItem.leftBarButtonItem = isShowKeyboard ? cancelButton : goBackButton
             feedbackText = videoInfoView.feedbackTextView.text!
             DataManager.shared.updateFeedback(videoInformation: currentVideoInformation!, feedback: feedbackText!)
-            navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         }
     }
     
     @objc func hideKeyboard(notification: NSNotification) {
         if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             isShowKeyboard.toggle()
-            self.navigationController?.navigationBar.layer.opacity = 0
-            self.topSafeAreaView.layer.opacity = 0
-            // 키보드의 유무에 따라 버튼 옵션 변경
-            navigationItem.leftBarButtonItem = isShowKeyboard ? cancelButton : goBackButton
             feedbackText = videoInfoView.feedbackTextView.text!
             DataManager.shared.updateFeedback(videoInformation: currentVideoInformation!, feedback: feedbackText!)
-            navigationController?.interactivePopGestureRecognizer?.isEnabled = true
         }
     }
     

--- a/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
@@ -101,9 +101,7 @@ class VideoDetailViewController: UIViewController {
         
         // 배경, 네비게이션바, 툴바 색 지정
         self.view.backgroundColor = .orrWhite
-        navigationController?.navigationBar.backgroundColor = .orrWhite
-        navigationController?.toolbar.backgroundColor = .orrWhite
-        
+//        navigationController?.toolbar.backgroundColor = .orrWhite
         navigationItem.leftBarButtonItem = goBackButton
        
         

--- a/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
@@ -58,10 +58,6 @@ class VideoDetailViewController: UIViewController {
         return view
     }()
     
-    // 영상 재생하는 뷰 (VideoPlayerView)
-    
-    
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         setNavigationBar()
@@ -83,8 +79,6 @@ class VideoDetailViewController: UIViewController {
         self.navigationController?.isNavigationBarHidden = false
         self.navigationController?.navigationBar.layer.opacity = 1
         self.topSafeAreaView.layer.opacity = 1
-        print("ruyha/색 살림")
-
     }
     
     // 네비게이션바 세팅 함수
@@ -128,7 +122,6 @@ class VideoDetailViewController: UIViewController {
     @objc func showInfo() {
         isShowInfo.toggle()
         infoButton.image = UIImage(systemName: isShowInfo ? "info.circle.fill" : "info.circle")
-//        navigationController?.hidesBarsOnTap = !isShowInfo
         feedbackText = videoInfoView.feedbackTextView.text!
         if isShowInfo {
             UIView.animate(withDuration: 0.2, animations: {


### PR DESCRIPTION
### 작업 내용 설명
간단한 이슈인줄 알았는데 내용이 조금 복잡해져서 오래 걸렸습니다.
설명이 길어도 양해 부탁드려요.


#### 원인 1  해당 코드는 네비게이션 back제스쳐를 사용,중지 할때 사용됩니다.
https://stackoverflow.com/questions/31731751/disable-swipe-back-gesture-in-swift
```swift
  navigationController?.interactivePopGestureRecognizer?.isEnabled  = 
```
문제는 저코드는 자신의 뷰에서만 동작하고 사라지는 코드가 아닌 전체적인 앱의 모든 뷰에 영향을 줍니다.
해당 코드는 앱의 여러곳에서 사용되고 있었습니다.

#### 원인 2 CustomBackBarButtomItem
해당 파일은 뒤로가기 영역확장을 위해 제작 되었습니다.
하지만 네비게이션컨트롤러에 기존 back버튼을 삭제 하게 되면 해당 제스쳐 또한 같이 사라지게 됩니다.
때문에 UINavigationController을 extension하여 해당 문제를 해결하였습니다.

#### 원인  3 네비게이션 바 색상변경
```swift 
        navigationController?.navigationBar.backgroundColor = .orrWhite
```
네비게이션 바의 백그라운드 색상 또한 한번 변경하면 계속 값이 유지 되기 때문에
색상을 설정해주는 코드가 한번 실행 되면 제스쳐를 사용해 뒤로가기를 할 때
바영역에 색이 남아 어색하게 보이는 이슈도 있었습니다. (이슈영상에서는 안보임)

#### 작업전 상태 
해당 이슈
https://github.com/DeveloperAcademy-POSTECH/MacC-TEAM-8bit/issues/241

이슈에서 보이는 오류 발생 방법은 다음과 같습니다.

1. 제스쳐를 통해 뒤로가기를 할때 키보드가 튀어나옴
=> 키보드를 올리는 시점을
viewWillAppear => viewDidAppear로 옮겨서 해결 했습니다.

2. 뒤로가기 제스쳐 차단은 디자이너 린다와 협의해 videoSlider (하단 영상의 진행도를 보여주는 바)를 수정하여 
videoSlider를 조작할때 뒤로가기 제스쳐가 발생하는 일이 없도록 수정하겠습니다.
(새로운 이슈 생성하여 작업 예정)

### 관련 이슈
- #241

### 작업의 결과물
#### 작엽 내용 요약
1. 전반적인 네이비게이션바 수정 (영상으로 올려도 티안나서 생략)
2. UINavigationController extension
3. VideoDetailViewController 에서 영상 피드백 작성시 취소 버튼이 아닌 키보드 Done 버튼으로 입력 종료

- 코드 or 스크린샷 or 동영상

### 작업의 비고사항 및 한계점
- 저에게 한계란 없습니다.

### To Reviewers
-  LevelAndPFSettingViewController 작업을 위해 해당 PR이 머지 되어야 합니다.

Close #241 
