### PR TITLE
[#280] feat - RouteDataManager 도전 상태 변경 메소드 구현

### DIFF
--- a/OrrRock/OrrRock/CoreData/RouteFinding/RouteCoreDataDAO.swift
+++ b/OrrRock/OrrRock/CoreData/RouteFinding/RouteCoreDataDAO.swift
@@ -79,6 +79,21 @@ class RouteCoreDataDAO {
         }
     }
     
+    func updateRouteInformationStatus(status: Bool, routeInformation: RouteInformation) {
+        guard let id = routeInformation.id else { return }
+        let request = RouteInformation.fetchRequest()
+        
+        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
+        do {
+            let info = try context.fetch(request)
+            if let tempInfo = info.first {
+                tempInfo.setValue(status, forKey: "isChallengeComplete")
+            }
+        } catch {
+            print("CoreDataDAO UpateRoute Method \(error.localizedDescription)")
+        }
+    }
+    
     func createPageInformation(pageInfo: PageInfo, routeInformation: RouteInformation) {
         let page = PageInformation(context: context)
         page.rowOrder = Int64(pageInfo.rowOrder)

--- a/OrrRock/OrrRock/CoreData/RouteFinding/RouteDataManager.swift
+++ b/OrrRock/OrrRock/CoreData/RouteFinding/RouteDataManager.swift
@@ -46,7 +46,7 @@ final class RouteDataManager {
         coreDataDAO.updateRouteInformationLevelAndStatus(status: status, problemLevel: level, routeInformation: routeInformation)
     }
     
-    func updateRouteStatus(statusTo status: Bool, of routeInformation: RouteInformation) {
+    func updateRouteStatus(to status: Bool, of routeInformation: RouteInformation) {
         coreDataDAO.updateRouteInformationStatus(status: status, routeInformation: routeInformation)
     }
     

--- a/OrrRock/OrrRock/CoreData/RouteFinding/RouteDataManager.swift
+++ b/OrrRock/OrrRock/CoreData/RouteFinding/RouteDataManager.swift
@@ -46,6 +46,10 @@ final class RouteDataManager {
         coreDataDAO.updateRouteInformationLevelAndStatus(status: status, problemLevel: level, routeInformation: routeInformation)
     }
     
+    func updateRouteStatus(statusTo status: Bool, of routeInformation: RouteInformation) {
+        coreDataDAO.updateRouteInformationStatus(status: status, routeInformation: routeInformation)
+    }
+    
     func addPageData(pageInfoList: [PageInfo], routeInformation: RouteInformation) {
         for info in pageInfoList {
             coreDataDAO.createPageInformation(pageInfo: info, routeInformation: routeInformation)


### PR DESCRIPTION
### 작업 내용 설명
1. `RouteFindingMainViewController`에서 필요한 도전 상태 변경 메소드 구현

### 관련 이슈
- #280

### 작업의 결과물
- 기존 코드의 경우, `RouteFindingFeatureViewController`에서 문제 난이도, 도전 상태를 동시에 변환가능한 메소드만 존재하였으나, `RouteFindingMainViewController`에서 도전 상태"만" 바꾸는 메소드가 필요하다는 요청에 의해 아래의 코드가 새롭게 추가되었습니다.
```swift
// RouteCoreDataDAO.swift
 func updateRouteInformationStatus(status: Bool, routeInformation: RouteInformation) {
        guard let id = routeInformation.id else { return }
        let request = RouteInformation.fetchRequest()
        
        request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
        do {
            let info = try context.fetch(request)
            if let tempInfo = info.first {
                tempInfo.setValue(status, forKey: "isChallengeComplete")
            }
        } catch {
            print("CoreDataDAO UpateRoute Method \(error.localizedDescription)")
        }
}
```
```swift
// RouteDataManager.swift
func updateRouteStatus(statusTo status: Bool, of routeInformation: RouteInformation) {
        coreDataDAO.updateRouteInformationStatus(status: status, routeInformation: routeInformation)
}
```
- 실제 UI계층에서 사용될 메소드는 `RouteDataManager`의 `updateRouteStatus`입니다.
- 해당 메소드에 대한 설명은 Wiki의 `Z_3`에 추가될 예정입니다.

### To Reviewers
- Missing된 메소드를 알려주신 도도 @commitcomplete 감사합니다 :)

Close #280
