### PR TITLE
[#284] fix 상단 여백 발생 이슈 및 하단 탭바 영역 이슈 해결

### DIFF
--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -1022,7 +1022,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = ML59XN7A6B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -1037,7 +1037,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -1056,7 +1056,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = ML59XN7A6B;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -1071,7 +1071,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/OrrRock/OrrRock.xcodeproj/project.pbxproj
+++ b/OrrRock/OrrRock.xcodeproj/project.pbxproj
@@ -1022,7 +1022,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = ML59XN7A6B;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -1037,7 +1037,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -1056,7 +1056,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
-				DEVELOPMENT_TEAM = ML59XN7A6B;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = OrrRock/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -1071,7 +1071,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.jhHwang.OrrRock;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/OrrRock/OrrRock/Home/HomeViewController.swift
+++ b/OrrRock/OrrRock/Home/HomeViewController.swift
@@ -232,15 +232,10 @@ final class HomeViewController : UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.navigationController?.navigationBar.isHidden = true
+        self.navigationController?.isNavigationBarHidden = true
         reloadTableViewWithOptions(filterOption: filterOption, sortOption: sortOption, orderOption: orderOption)
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        self.navigationController?.navigationBar.isHidden = false
-    }
     
     // MARK: 다크모드 대응 코드
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/OrrRock/OrrRock/MyActivity/MyActivityViewController.swift
+++ b/OrrRock/OrrRock/MyActivity/MyActivityViewController.swift
@@ -142,7 +142,6 @@ class MyActivityViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationController?.navigationBar.isHidden = true
         self.view.backgroundColor = .orrGray050
     }
     
@@ -157,7 +156,9 @@ class MyActivityViewController: UIViewController {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+
     }
+    
     
     func setUpData() {
         let entireVideoInformationsByDate: [[VideoInformation]] = DataManager.shared.repository.sortVideoInformation(filterOption: .all, sortOption: .gymVisitDate)

--- a/OrrRock/OrrRock/RouteFinding/RouteFindingMainViewController.swift
+++ b/OrrRock/OrrRock/RouteFinding/RouteFindingMainViewController.swift
@@ -92,11 +92,6 @@ final class RouteFindingMainViewController: UIViewController {
         self.navigationController?.isNavigationBarHidden = true
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        self.navigationController?.isNavigationBarHidden = false
-    }
-    
     private func setUpSegment() {
         self.segmentedControl.selectedSegmentIndex = 0
         if let firstVC = dataViewControllers.first {

--- a/OrrRock/OrrRock/Upload/DateSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/DateSettingViewController.swift
@@ -51,8 +51,12 @@ class DateSettingViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .orrWhite
         self.navigationController?.setExpansionBackbuttonArea()
-        self.navigationController?.isNavigationBarHidden = false
         setUpLayout()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.isNavigationBarHidden = false
     }
 }
 

--- a/OrrRock/OrrRock/Upload/DateSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/DateSettingViewController.swift
@@ -51,7 +51,7 @@ class DateSettingViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .orrWhite
         self.navigationController?.setExpansionBackbuttonArea()
-        
+        self.navigationController?.isNavigationBarHidden = false
         setUpLayout()
     }
 }

--- a/OrrRock/OrrRock/VideoDetail/VideoCollection/VideoCollectionViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/VideoCollection/VideoCollectionViewController.swift
@@ -32,7 +32,7 @@ class VideoCollectionViewController: UIViewController {
                 indexCountLabel.text = "항목 선택"
                 toolbarText.customView = indexCountLabel
                 self.navigationController?.setExpansionBackbuttonArea()
-
+                navigationItem.leftBarButtonItem = nil
                 videoCollectionView.allowsMultipleSelection = false
                 self.navigationController?.setToolbarHidden(true, animated: true)
             case .select:

--- a/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
+++ b/OrrRock/OrrRock/VideoDetail/VideoDetailViewController/VideoDetailViewController.swift
@@ -77,6 +77,7 @@ class VideoDetailViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(false)
         self.navigationController?.isNavigationBarHidden = false
+        self.navigationController?.setToolbarHidden(true, animated: false)
         self.navigationController?.navigationBar.layer.opacity = 1
         self.topSafeAreaView.layer.opacity = 1
     }


### PR DESCRIPTION
### 작업 내용 설명
1. 영상 선택 및 편집화면에서 전체선택 버튼이 변경되지 않는 이슈 해결 
2. 다른탭 전환시 상단에 여백이 생기는 이슈 해결
3. 기록 -> 목록형 -> 영상 상세 -> 이전페이지 시 목록형의 탭바영역이 살아 있는 이슈 해결 

#### 1. 네비게이션이 다른 화면에도 상태가 유지 되는 이유 
아래의 코드는 SceneDelegate에 존재하는 코드입니다.
```swift
class SceneDelegate: UIResponder, UIWindowSceneDelegate {

func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
        guard let windowScene = (scene as? UIWindowScene) else { return }
        window = UIWindow(windowScene: windowScene)
        window?.backgroundColor = .black
       // MainViewController를 UINavigationController로 만들어 사용중
        window?.rootViewController = UINavigationController(rootViewController: MainViewController())
        window?.makeKeyAndVisible()
    }
```
간단하게 설명하면 MainViewController() 는 탭바를 가지고 있는 VC이고 이는 네비게이션 컨트롤러로 설정이 되어 있습니다.
때문에 모든 네비게이션 전환시 MainViewController()위에 스택이 쌓이는 방식으로 뷰가 뷰잉됩니다.
즉 어떤 탭이든 같은 rootview를 가지고있기에 옵션이 공유 되는 이슈가 있습니다.
해당 이슈를 해결하기위에 

각각의 탭의 뷰를 UINavigationController로 설정해 봤지만 탭바 는 각각의 탭뷰 위에 존재 함으로
네비게이션 전환으로 띄운 뷰가 탭바 아래에 있는 이슈가 발생해 기존의 상태를 유지 시켰습니다.

#### 2. 어떻게 해결 했나요? (상단여백이슈)
각각의 탭바를 터치시 실행되는 뷰들의 생명주기 함수에 isNavigationBarHidden옵션을 설정해 가려주는 방식으로 
상단 영역이 생기는 이슈를 해결 했습니다.
```swift
        let myActivityViewController = MyActivityViewController()
        let homeViewController = HomeViewController()
        let routeFindingViewController = RouteFindingMainViewController()

    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
       //네비게에션바 숨김 옵션
        self.navigationController?.isNavigationBarHidden = true
      //사용하는경우 같은 위치에 false로 옵션을 줍니다.
    }
```
추가로 아래의 코드처럼 뷰가 사라지려 할 떄 옵션을 꺼도 실제로는 적용이 안되는 이슈가 있어
필요한 상황에서 옵션을 껏켯 해야 합니다.
```swift
    override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(animated) 
        //다시 살림
        self.navigationController?.isNavigationBarHidden = false
    }
```
A뷰 에서 B뷰로 전환 B viewWillAppear실행 
B뷰를 닫으려 할때 A viewWillAppear선실행 B viewWillDisappear실행함으로
네비게이션 숨김이 활성화 후 바로 비활성화되어 각각의 탭바 전환시 상단에 영역이 생기는 이슈였습니다.
이러한 작업을 할 때는 전환 되는 뷰도 같이 테스트를 해줘야 문제를 해결 할 수 있습니다.

#### 코드상 간단한 변경인데 작업인데 오래 걸린이유 
해당 이슈를 해결 하기 위해서는 전체적인 뷰들이 사용하고 있는 옵션을 전부 하나하나 확인해야 했으며
각각의 뷰들이 전환되는 상태를 일일이 확인해야 했습니다.
그리고 전체적인 구조도 이해할 필요가 조금은 있어야했습니다.
제가 작성한 코드가 아닌 부분들을 파악하는데 시간이 오래 걸렸고 한개의 뷰가 아닌 여러 뷰를 같이 파악애야 해서 
시간이 조금 걸렸어요... ㅠㅜ


### 관련 이슈
- #284


### 작업의 결과물

1. 영상 선택 및 편집화면에서 전체선택 버튼이 변경되지 않는 이슈 해결 
 
|편집화면|편집끝|
|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/103024840/204337509-3f70cd23-1e2b-4cc5-9c58-930a55f0cfde.PNG">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/103024840/204337421-c92a07fd-879b-476e-86d0-80dbf058af3c.PNG">|

2. 다른탭 전환시 상단에 여백이 생기는 이슈 해결

|개선전|개선후|
|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/103024840/204339558-c4a88186-f588-464f-8b53-9cc2245f4339.PNG">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/103024840/204339549-f8bd95af-6001-40df-a5d1-361edf2949c7.PNG">|

3. 기록 -> 목록형 -> 영상 상세 -> 이전페이지 시 목록형의 탭바영역이 살아 있는 이슈 해결 

|개선전|개선후|
|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/103024840/204339915-d811e96c-1e49-4268-83b8-fd1038e50a80.PNG">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/103024840/204339935-10fa102f-298b-4e68-a3ba-a2d5378f1831.PNG">|


### 작업의 비고사항 및 한계점
- 시간이 걸려도 저에게 한계란 없습니다.
- 네비게이이션 이슈 해결을 도와준 @hminkim 꼬마에게 감사를...


### To Reviewers
- 리뷰 부탁해요~~


Close #284
