### PR TITLE
[#289] fix - RouteFindingCameraViewController 오류 수정

### DIFF
--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+AVCapturePhotoCaptureDelegate.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+AVCapturePhotoCaptureDelegate.swift
@@ -53,7 +53,5 @@ extension RouteFindingCameraViewController: AVCapturePhotoCaptureDelegate {
         // MARK: **TEST** 이미지 넘김 테스트용 코드
         guard let image = photoImage else { return }
         navigateToSampleImageVC(image: image)
-        
-        buttonActiveStatus(to: false)
     }
 }

--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+AVCapturePhotoCaptureDelegate.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+AVCapturePhotoCaptureDelegate.swift
@@ -53,5 +53,7 @@ extension RouteFindingCameraViewController: AVCapturePhotoCaptureDelegate {
         // MARK: **TEST** 이미지 넘김 테스트용 코드
         guard let image = photoImage else { return }
         navigateToSampleImageVC(image: image)
+        
+        buttonActiveStatus(to: false)
     }
 }

--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+AVCapturePhotoCaptureDelegate.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+AVCapturePhotoCaptureDelegate.swift
@@ -12,7 +12,7 @@ import Photos
 extension RouteFindingCameraViewController: AVCapturePhotoCaptureDelegate {
     
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-        guard error != nil else {
+        guard error == nil else {
             print("Error capturing photo: \(error)")
             return
         }
@@ -28,7 +28,7 @@ extension RouteFindingCameraViewController: AVCapturePhotoCaptureDelegate {
     
     func photoOutput(_ output: AVCapturePhotoOutput, didFinishCaptureFor resolvedSettings: AVCaptureResolvedPhotoSettings, error: Error?) {
         
-        guard error != nil else {
+        guard error == nil else {
             print("Error capturing photo: \(error)")
             return
         }

--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+PHPickerViewControllerDelegate.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+PHPickerViewControllerDelegate.swift
@@ -22,8 +22,12 @@ extension RouteFindingCameraViewController: PHPickerViewControllerDelegate {
         let imageRequestOption = PHImageRequestOptions()
         imageRequestOption.isNetworkAccessAllowed = true
         
+        CustomIndicator.startLoading()
+        
         PHImageManager.default().requestImageDataAndOrientation(for: phAsset, options: imageRequestOption) { [self] data, _, _, _ in
             if let data = data, let image = UIImage(data: data) {
+                
+                CustomIndicator.stopLoading()
                 
                 let orientationFixedImage = image.fixOrientation()
                 let rect = orientationFixedImage.imageRectAs16to9()
@@ -33,6 +37,8 @@ extension RouteFindingCameraViewController: PHPickerViewControllerDelegate {
                 // MARK: **TEST** 이미지 넘김 테스트용 코드
                 guard let image = photoImage else { return }
                 navigateToSampleImageVC(image: image)
+            } else {
+                CustomIndicator.stopLoading()
             }
         }
         dismiss(animated: true)

--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+PHPickerViewControllerDelegate.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController+PHPickerViewControllerDelegate.swift
@@ -18,7 +18,11 @@ extension RouteFindingCameraViewController: PHPickerViewControllerDelegate {
         currentLocalIdentifier = fetchResult[0].localIdentifier
         
         guard let phAsset = PHAsset.fetchAssets(withLocalIdentifiers: identifiers, options: nil).firstObject else { return }
-        PHImageManager.default().requestImageDataAndOrientation(for: phAsset, options: nil) { [self] data, _, _, _ in
+        
+        let imageRequestOption = PHImageRequestOptions()
+        imageRequestOption.isNetworkAccessAllowed = true
+        
+        PHImageManager.default().requestImageDataAndOrientation(for: phAsset, options: imageRequestOption) { [self] data, _, _, _ in
             if let data = data, let image = UIImage(data: data) {
                 
                 let orientationFixedImage = image.fixOrientation()

--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
@@ -155,7 +155,7 @@ private extension RouteFindingCameraViewController {
     @objc private func showPhotoPicker() {
         let photoLibrary = PHPhotoLibrary.shared()
         var config = PHPickerConfiguration(photoLibrary: photoLibrary)
-        config.filter = .images
+        config.filter = .all(of: [.images, .not(.panoramas), .not(PHPickerFilter.playbackStyle(.imageAnimated))])
         config.preferredAssetRepresentationMode = .current
         config.selectionLimit = 1
         let picker = PHPickerViewController(configuration: config)

--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
@@ -98,8 +98,8 @@ final class RouteFindingCameraViewController: UIViewController {
 }
 
 // MARK: Layout & Property Setting Function
-private extension RouteFindingCameraViewController {
-    func setUpLayout() {
+extension RouteFindingCameraViewController {
+    private func setUpLayout() {
         
         let shutterButtonSize: CGFloat = 75
         let safeArea = view.safeAreaLayoutGuide
@@ -142,10 +142,16 @@ private extension RouteFindingCameraViewController {
         })
     }
     
-    func makePropertyEmpty() {
+    private func makePropertyEmpty() {
         photoImage = nil
         photoData = nil
         currentLocalIdentifier = nil
+    }
+    
+    func buttonActiveStatus(to status: Bool) {
+        photosButton.isUserInteractionEnabled = status
+        shutterButton.isUserInteractionEnabled = status
+        closeButton.isUserInteractionEnabled = status
     }
 }
 
@@ -164,6 +170,9 @@ private extension RouteFindingCameraViewController {
     }
     
     @objc private func capturePhoto() {
+        
+        buttonActiveStatus(to: false)
+        
         let settings = AVCapturePhotoSettings()
         sessionQueue.async {
             self.photoOutput?.capturePhoto(with: settings, delegate: self)
@@ -266,6 +275,7 @@ private extension RouteFindingCameraViewController {
     
     // 카메라 세션 실행
     private func executeCameraSession() {
+        buttonActiveStatus(to: true)
         sessionQueue.async { [self] in
             switch cameraAuthorizeStatus {
             case .success:


### PR DESCRIPTION
### 작업 내용 설명
1. UIImage Type으로 들고올 수 없는 사진에 대해 처리하기
2. iCloud 및 네트워크 환경을 사용해야하는 사진에 대한 처리하기
 2 - a. 네트워크 환경을 사용해야하는 경우, Loading Indicator 넣기
3. 카메라를 사용하는 경우, 정상적으로 사진을 찍었음에도 사진이 불러와지지 않는 에러 해결하기
4. 카메라 버튼 터치 시, 다른 버튼과의 Interaction 제한

### 관련 이슈
- #289

### 작업의 결과물
**UIImage Type으로 들고올 수 없는 사진에 대한 처리**
```swift
// RouteFindingCameraViewController.swift line.157 - line.158
var config = PHPickerConfiguration(photoLibrary: photoLibrary)
config.filter = .all(of: [.images, .not(.panoramas), .not(PHPickerFilter.playbackStyle(.imageAnimated))])
```
- PHPickerConfiguration의 filter를 통해 UIImage로 불러올 수 없는 자료를 제한적으로 보여주도록 구현했습니다.
- 도움을 주신 류하 @RuyHa 감사합니다!

**iCloud 및 네트워크 환경을 사용해야하는 사진에 대한 처리**
- `PHImageRequestOptions`의 `isNetworkAccessAllowed`를 `true`로 변환합니다.
- 도움을 주신 꼬마 @hminkim 감사합니다!
```swift
// RouteFindingCameraViewController+PHPickerViewControllerDelegate.swift line.21 - line.22
let option = PHImageRequestOptions()
option.isNetworkAccessAllowed = true
```
- 이미지 데이터를 들고올 때 시간이 걸리는 경우에 대하여 인디케이터를 띄우도록 구현했습니다.
```swift
// RouteFindingCameraViewController+PHPickerViewControllerDelegate.swift line.24 - line.40
        CustomIndicator.startLoading() // 아래의 request에서 시간이 걸리기에 여기서 Indicator를 start한다.
        
        PHImageManager.default().requestImageDataAndOrientation(for: phAsset, options: imageRequestOption) { [self] data, _, _, _ in
            if let data = data, let image = UIImage(data: data) {
                
                CustomIndicator.stopLoading() // 이미지 데이터를 정상적으로 불러온 경우 Indicator를 멈춘다.
                
                let orientationFixedImage = image.fixOrientation()
                let rect = orientationFixedImage.imageRectAs16to9()
                
                photoImage = orientationFixedImage.cropped(rect: rect)
                
                // MARK: **TEST** 이미지 넘김 테스트용 코드
                guard let image = photoImage else { return }
                navigateToSampleImageVC(image: image)
            } else {
                CustomIndicator.stopLoading() // 이미지 데이터를 정상적으로 불러오지 못한 경우에도 Indicator를 멈춘다.
            }
        }
```
**카메라를 사용하는 경우, 정상적으로 사진을 찍었음에도 사진이 불러와지지 않는 에러 해결**
- `if let` -> `guard let`으로 변경하는 과정에서 `error가 있는 경우에만 수행되는 코드`의 형태로 작성하여 발생한 문제였습니다.

```swift
// RouteFindingCameraViewController+AVCapturePhotoCaptureDelegate.swift

// 기존 코드
guard error != nil else {
    print("Error capturing photo: \(error)")
    return
}
// 변경된 코드
guard error == nil else {
    print("Error capturing photo: \(error)")
    return
}
```
**카메라 버튼 터치 시, 다른 버튼과의 Interaction 제한**
- 카메라 버튼 터치 후 이미지가 추출되어 다음 View Controller로 넘어가기까지 시간이 걸립니다.
- 이러한 경우에 대하여 RouteFindingCameraViewController에서 사용자와의 Interaction이 필요한 버튼들을 일시적으로 막을 필요가 있습니다.
- 아래의 메소드를 통해 사용자와 버튼의 Interaction 상태를 변경합니다.
```swift
// RouteFindingCameraViewController.swift line.151 - line.155
func buttonActiveStatus(to status: Bool) {
    photosButton.isUserInteractionEnabled = status
    shutterButton.isUserInteractionEnabled = status
    closeButton.isUserInteractionEnabled = status
}
```
[![](https://mermaid.ink/img/pako:eNp1UD9Lw0AU_yqPm5tBxwxC2owi0oLLXZAzeW0OkrtweVeRtlsmZ4cKCjq6ibgU-o2SfAePZhFbh_d4w-_f-61YajJkIVtYWeVwORX6Si65H7WQpIyGqTEUwo3Ce5gYTdYUBVqIEgiCC1hXrs7X137xv4hxIvSMpCV-khtAxLvdd_vx1L7uof1q-sc99M1nt9sO0mN-54iMjlJSS_RK5OpbMuFcFjUOkMmxafv-At1b0z9vvX18ItSBGJ8dh_rFHDDn_wQg6zBhI1aiLaXKfHcroQEEoxxLFCz0Z4Zz6QoSTOiNh0pHZvagU3Ygj5irMkkYK-lbL9nw0uYHBamXGg?type=png)](https://mermaid.live/edit#pako:eNp1UD9Lw0AU_yqPm5tBxwxC2owi0oLLXZAzeW0OkrtweVeRtlsmZ4cKCjq6ibgU-o2SfAePZhFbh_d4w-_f-61YajJkIVtYWeVwORX6Si65H7WQpIyGqTEUwo3Ce5gYTdYUBVqIEgiCC1hXrs7X137xv4hxIvSMpCV-khtAxLvdd_vx1L7uof1q-sc99M1nt9sO0mN-54iMjlJSS_RK5OpbMuFcFjUOkMmxafv-At1b0z9vvX18ItSBGJ8dh_rFHDDn_wQg6zBhI1aiLaXKfHcroQEEoxxLFCz0Z4Zz6QoSTOiNh0pHZvagU3Ygj5irMkkYK-lbL9nw0uYHBamXGg)

### To Reviewers
- ♥️

Close #289