### PR TITLE
[#338] feat - 루트파인딩 화면 내 이미지 화질 개선

### DIFF
--- a/OrrRock/OrrRock/Extensions/String+.swift
+++ b/OrrRock/OrrRock/Extensions/String+.swift
@@ -41,7 +41,7 @@ extension String {
     
     // MARK: String -> UIImage 변환 메서드
     // PHAsset Local Identifier로부터 영상 썸네일을 생성해 반환
-    func generateCardViewThumbnail() -> UIImage? {
+    func generateCardViewThumbnail(targetSize: CGSize = CGSize(width: 500, height: 500)) -> UIImage? {
         
         guard let asset: PHAsset = PHAsset.fetchAssets(withLocalIdentifiers: [self], options: .none).firstObject else { return nil }
         
@@ -53,7 +53,7 @@ extension String {
         var thumbnail = UIImage()
         
         manager.requestImage(for: asset,
-                             targetSize:  CGSize(width: 500, height: 500),
+                             targetSize:  targetSize,
                              contentMode: .aspectFit,
                              options: option,
                              resultHandler: {(result, info) -> Void in

--- a/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController+Extensions.swift
+++ b/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController+Extensions.swift
@@ -58,7 +58,7 @@ extension RouteFindingSectionViewController: UICollectionViewDataSource {
         cell.cellChallengeLabel.text = routeInformations[index].isChallengeComplete ? "도전 성공" : "도전 중"
         cell.cellDateLabel.text = routeInformations[index].dataWrittenDate.timeToString()
         cell.cellTitleLabel.text = routeInformations[index].gymName
-        cell.cellImage.image = routeFindingDataManager?.getRouteFindingList()[index].imageLocalIdentifier.generateCardViewThumbnail()
+        cell.cellImage.image = routeFindingDataManager?.getRouteFindingList()[index].imageLocalIdentifier.generateCardViewThumbnail(targetSize: CGSize(width: 1200, height: 1200))
         cell.isSelectable = mMode == .select ? true : false
         return cell
     }

--- a/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController.swift
@@ -151,7 +151,7 @@ class RouteFindingDetailViewController: UIViewController {
         var routeViewControllers: [RouteViewController] = []
         
         routeDataDraft.routeInfoForUI.pages.forEach { pageInfo in
-            routeViewControllers.append(RouteViewController(pageInfo: pageInfo, backgroundImage: routeDataDraft.routeInfoForUI.imageLocalIdentifier.generateCardViewThumbnail()!))
+            routeViewControllers.append(RouteViewController(pageInfo: pageInfo, backgroundImage: routeDataDraft.routeInfoForUI.imageLocalIdentifier.generateCardViewThumbnail(targetSize: CGSize(width: 2400, height: 2400))!))
         }
         
         return routeViewControllers
@@ -183,7 +183,7 @@ class RouteFindingDetailViewController: UIViewController {
     }
     
     @objc func editAction() {
-        guard let image = routeDataDraft.routeInfoForUI.imageLocalIdentifier.generateCardViewThumbnail() else { return }
+        guard let image = routeDataDraft.routeInfoForUI.imageLocalIdentifier.generateCardViewThumbnail(targetSize: CGSize(width: 2400, height: 2400)) else { return }
         
         let featureVC = RouteFindingFeatureViewController(routeDataDraft: routeDataDraft, backgroundImage: image)
         


### PR DESCRIPTION
### 작업 내용 설명
1. `generateCardViewThumbnail` 메소드 매개변수 설정
2. `RouteFindingSectionViewController thumbnail` 화질 개선
3. `RouteFindingDetailViewController thumbnail` 화질 개선

### 관련 이슈
- #338

### 작업의 결과물
**수정된 메소드**
- 시그니처 변경문 추가
```swift
// 기존
func generateCardViewThumbnail() -> UIImage?

// 변경
func generateCardViewThumbnail(targetSize: CGSize = CGSize(width: 500, height: 500)) -> UIImage?
```
**`RouteFindingSectionViewController thumbnail` 화질 개선**

|기존|수정|
|:---:|:---:|
|![_1](https://user-images.githubusercontent.com/96641477/204997540-8e7fe973-23e6-4130-bb8b-9887f87b3221.jpeg)|![_3](https://user-images.githubusercontent.com/96641477/204997552-be6ff36a-d68c-4cda-a648-20b846bec50a.jpeg)|


**`RouteFindingDetailViewController thumbnail` 화질 개선**
|기존|수정|
|:---:|:---:|
|![_2](https://user-images.githubusercontent.com/96641477/204997550-62258885-3cd1-4715-9f41-f361450d3b95.jpeg)|![_4](https://user-images.githubusercontent.com/96641477/204997556-89aecba1-2dd8-4151-ab66-8fc0ede8888d.jpeg)|
### 작업의 비고사항 및 한계점
- 값으로 thumbnail의 화질을 바로 지정하고 있습니다.

### To Reviewers
- ♥️

Close #338
