### PR TITLE
[#352] - fix 루트파인딩 업로드 카메라 뷰 배경 삽입

### DIFF
--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
@@ -66,6 +66,7 @@ final class RouteFindingCameraViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        view.backgroundColor = .black
         setUpLayout()
         setPhotosButtonImage()
         


### PR DESCRIPTION
### 작업 내용 설명
1. `RouteFindingCameraViewController`에 배경 색상을 설정했습니다.

### 관련 이슈
- #352 

### 작업의 결과물
**`RouteFindingCameraViewController`에 `UIColor.black`으로 배경색상을 설정했습니다.**
<img width = "300" alt="" src="https://user-images.githubusercontent.com/96641477/205052562-6a582a8b-ef67-46c2-ab64-f2510113c383.PNG">

### To Reviewers
- ♥️

Close #352