### PR TITLE
[#356] fix - 루트파인딩 기능 뷰 내 X 버튼의 Alert 추가

### DIFF
--- a/OrrRock/OrrRock/CoreData/RouteFinding/RouteDataDraft.swift
+++ b/OrrRock/OrrRock/CoreData/RouteFinding/RouteDataDraft.swift
@@ -38,23 +38,20 @@ final class RouteDataDraft {
         routeInfoForUI = route.convertToRouteInfo()
     }
     
-    func save() -> RouteInfo? {
+    func save() {
           
         var routeInfo: RouteInfo? = nil
         // MODE: ADD_데이터 추가
         if route == nil {
             routeDataManager.addRoute(routeInfo: routeInfoForUI)
             routeDataManager.saveData()
-            return nil
         } else { // MODE: EDIT_데이터 수정
-            guard let routeInformation = route else { return nil}
+            guard let routeInformation = route else { return }
             routeDataManager.deleteRouteData(routeInformation: routeInformation)
             routeDataManager.addRoute(routeInfo: routeInfoForUI)
             routeDataManager.saveData()
             routeInfo = routeInfoForUI
         }
-        return routeInfo
-        
     }
     
     // MARK: CREATE PAGE

--- a/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
@@ -284,7 +284,7 @@ final class RouteFindingFeatureViewController: UIViewController {
         if let navigationController = self.navigationController {
             self.navigationController?.pushViewController(routeFindingSaveViewController, animated: true)
         } else {
-            routeDataDraft.routeInfoForUI = routeDataDraft.save()
+            routeDataDraft.save()
             self.dismiss(animated: true)
         }
         

--- a/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
@@ -289,7 +289,7 @@ final class RouteFindingFeatureViewController: UIViewController {
     }
     
     func showExitAlert() {
-        let optionMenu = UIAlertController(title: "저장하지 않고 나가기", message: "지금 나가면 변경 사항이 삭제됩니다.", preferredStyle: .alert)
+        let optionMenu = UIAlertController(title: "저장하지 않고 나가기", message: "지금 나가면 변경 사항이\r\n삭제됩니다.", preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) {_ in
             self.dismiss(animated: true, completion: nil)
         }

--- a/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
@@ -95,7 +95,7 @@ final class RouteFindingFeatureViewController: UIViewController {
         button.imageEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         button.tintColor = .orrWhite
         button.addAction(UIAction { _ in
-            self.exitRouteFinding()
+            self.showExitAlert()
         }, for: .touchUpInside)
         return button
     }()
@@ -202,7 +202,6 @@ final class RouteFindingFeatureViewController: UIViewController {
             self.present(onboardingVC, animated: true, completion: nil)
         }
         
-        
         setUpLayout()
         setUpThumbnailCollectionDelegate()
         setUpPageViewController()
@@ -289,11 +288,18 @@ final class RouteFindingFeatureViewController: UIViewController {
         print("Done Button Tapped")
     }
     
-    func exitRouteFinding() {
+    func showExitAlert() {
+        let optionMenu = UIAlertController(title: "저장하지 않고 나가기", message: "지금 나가면 변경 사항이 삭제됩니다.", preferredStyle: .alert)
+        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) {_ in
+            self.dismiss(animated: true, completion: nil)
+        }
         
-        // TODO: 루트파인딩 데이터 초기화 및 뷰 닫기
-        self.dismiss(animated: true, completion: nil)
-        print("Exit Button Tapped")
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        optionMenu.addAction(deleteAction)
+        optionMenu.addAction(cancelAction)
+        
+        self.present(optionMenu, animated: true, completion: nil)
     }
     
     func tapHandButton() {

--- a/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
@@ -13,6 +13,7 @@ final class RouteFindingFeatureViewController: UIViewController {
     // MARK: Variables
     
     var routeDataDraft: RouteDataDraft
+    var tempRouteInfo: RouteInfo
     var pageViewControllerList: [RouteFindingPageViewController] = []
     var backgroundImage: UIImage
     
@@ -177,6 +178,8 @@ final class RouteFindingFeatureViewController: UIViewController {
     
     init(routeDataDraft: RouteDataDraft, backgroundImage: UIImage) {
         self.routeDataDraft = routeDataDraft
+        self.tempRouteInfo = routeDataDraft.routeInfoForUI
+        
         self.backgroundImage = backgroundImage
         
         super.init(nibName: nil, bundle: nil)
@@ -291,6 +294,8 @@ final class RouteFindingFeatureViewController: UIViewController {
     func showExitAlert() {
         let optionMenu = UIAlertController(title: "저장하지 않고 나가기", message: "지금 나가면 변경 사항이\r\n삭제됩니다.", preferredStyle: .alert)
         let deleteAction = UIAlertAction(title: "삭제", style: .destructive) {_ in
+            self.routeDataDraft.routeInfoForUI = self.tempRouteInfo
+            
             self.dismiss(animated: true, completion: nil)
         }
         


### PR DESCRIPTION
### 작업 내용 설명
**1. X버튼 Alert 만들기**

### 관련 이슈
- #356

### 작업의 결과물
**- Alert 메소드 `showExitAlert` 구현**
```swift
    func showExitAlert() {
        let optionMenu = UIAlertController(title: "저장하지 않고 나가기", message: "지금 나가면 변경 사항이\r\n삭제됩니다.", preferredStyle: .alert)
        let deleteAction = UIAlertAction(title: "삭제", style: .destructive) {_ in
            self.dismiss(animated: true, completion: nil)
        }
        
        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
        
        optionMenu.addAction(deleteAction)
        optionMenu.addAction(cancelAction)
        
        self.present(optionMenu, animated: true, completion: nil)
    }
```
**- Sketch의 문구가 두 줄로 나뉘어 있어 줄을 두 개로 나누어 처리했습니다.**
```
message: "지금 나가면 변경 사항이\r\n삭제됩니다."
```
|Sketch 기반 디자인|실제 구현 사항|
|:---:|:---:|
|<img width="264" alt="image" src="https://user-images.githubusercontent.com/39216546/205043157-00854a54-5cb8-425e-b7b8-45c85061e83f.png">|<img width="264" alt="image" src="https://user-images.githubusercontent.com/96641477/205060620-f1f99f6c-dfae-4220-8e70-731388129e16.PNG">|
- Alert를 띄우는 메소드 `showExitAlert`의 작성으로 기존에 존재하던 `exitRouteFinding`가 불필요하다고 느껴 해당 코드부를 삭제 후 `showExitAlert`로 대체했습니다.

### To Reviewers
**To LED(@sm-amoled)**
**- 코드의 작성자인 레드 @sm-amoled Approve 이후 Merge가 가능합니다.**
**- PR 작성자 엘리제 @jeong-hyeonHwang 가 부재할 경우 @sm-amoled 에게 Merge 권한을 위임합니다.**
**- 코드의 세부 사항이 이슈 의도와 맞지 않다고 생각되면 Close 해주세요 :)**

Close #356 