### PR TITLE
[#350] feat - 루트파인딩 저장하기 뷰 내 디테일 수정

### DIFF
--- a/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
+++ b/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
@@ -286,7 +286,7 @@ extension RouteFindingSaveViewController {
             // 물리버튼이 있는 iPhone 8 이하 or SE 버전 디바이스
             view.addSubview(countVideoView)
             countVideoView.snp.makeConstraints {
-                $0.bottom.equalTo(skipButton.snp.top).offset(-54) // TODO: 린다와 패딩 협의 필요
+                $0.bottom.equalTo(skipButton.snp.top).offset(-54)
                 $0.centerX.equalToSuperview()
                 $0.height.equalTo(24)
                 $0.width.equalTo(71)

--- a/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
+++ b/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
@@ -196,7 +196,7 @@ class RouteFindingSaveViewController: UIViewController {
     }
     
     @objc func saveAction() {
-        let image = previewImageView.asImage()
+        guard let image = previewImageView.image else { return }
         UIImageWriteToSavedPhotosAlbum(image, self, nil, nil)
         completeSaveImage()
     }

--- a/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
+++ b/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
@@ -196,9 +196,33 @@ class RouteFindingSaveViewController: UIViewController {
     }
     
     @objc func saveAction() {
-        guard let image = previewImageView.image else { return }
-        UIImageWriteToSavedPhotosAlbum(image, self, nil, nil)
-        completeSaveImage()
+        // 액션시트 생성
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        
+        // 묶음사진 전체 저장 로직 생성
+        let saveAllImage = UIAlertAction(title: "묶음사진 전체 저장", style: UIAlertAction.Style.default) { [self] _ in
+            let pageimages = pageImages
+            for pageimage in pageimages {
+                UIImageWriteToSavedPhotosAlbum(pageimage, self, nil, nil)
+            }
+            completeSaveImage()
+        }
+        // 이 사진만 저장 로직 생성
+        let saveThisImage = UIAlertAction(title: "이 사진만 저장", style: UIAlertAction.Style.default) { [self] _ in
+            guard let image = previewImageView.image else { return }
+            UIImageWriteToSavedPhotosAlbum(image, self, nil, nil)
+            completeSaveImage()
+        }
+        // 취소 로직 생성
+        let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel)
+        
+        // 액션시트에 액션 추가
+        alert.addAction(saveAllImage)
+        alert.addAction(saveThisImage)
+        alert.addAction(cancelAction)
+        
+        // 액션시트 표시
+        self.present(alert, animated: true)
     }
     
     @objc func completeSaveImage() {

--- a/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
+++ b/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
@@ -105,7 +105,7 @@ class RouteFindingSaveViewController: UIViewController {
         label.textColor = UIColor.white
         label.font = UIFont.systemFont(ofSize: 14.0)
         label.textAlignment = .center
-        label.text = "이 루트파인딩을 사진에 저장했습니다."
+        label.text = ""
         
         return label
     }()
@@ -205,13 +205,13 @@ class RouteFindingSaveViewController: UIViewController {
             for pageimage in pageimages {
                 UIImageWriteToSavedPhotosAlbum(pageimage, self, nil, nil)
             }
-            completeSaveImage()
+            completeSaveImage(isSaveAll: true)
         }
         // 이 사진만 저장 로직 생성
         let saveThisImage = UIAlertAction(title: "이 사진만 저장", style: UIAlertAction.Style.default) { [self] _ in
             guard let image = previewImageView.image else { return }
             UIImageWriteToSavedPhotosAlbum(image, self, nil, nil)
-            completeSaveImage()
+            completeSaveImage(isSaveAll: false)
         }
         // 취소 로직 생성
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel)
@@ -225,9 +225,15 @@ class RouteFindingSaveViewController: UIViewController {
         self.present(alert, animated: true)
     }
     
-    @objc func completeSaveImage() {
+    @objc func completeSaveImage(isSaveAll: Bool) {
         
         self.toastMessageView.alpha = 0
+        
+        if isSaveAll == true {
+            toastMessage.text = "모든 루트파인딩을 사진에 저장했습니다."
+        } else {
+            toastMessage.text = "이 루트파인딩을 사진에 저장했습니다."
+        }
         
         view.addSubview(toastMessageView)
         toastMessageView.snp.makeConstraints {


### PR DESCRIPTION
### 작업 내용 설명
1. 이미지 모서리 라운딩 크롭되어 저장되고 있는 문제 해결
    - 기존에 `previewImageView`를 저장하여 뷰에 띄워주는 `cornerRadious`가 적용된 이미지가 저장되었음
    - `UIImageView`였던 `previewImageView`에서 `UIImage`로 다운캐스팅 한 이미지를 저장 시키게 로직 수정
2. 기존 이미지가 하나만 저장되는 이슈 해결
    - 기존에 우측 상단 저장 버튼으로 `previewImageView`에 띄워준 이미지 하나만 저장하였음
    - 기획팀과의 의논 후 <u>기획 의도와 맞지 않다고 판단</u>하여 모든 루트파인딩 이미지를 저장하는 기능 추가
    - 우측 상단 저장 버튼 클릭으로 이미지를 하나만 저장할 것인지 모두 저장할 것인지 `ActionSheet`를 띄워주게 변경
        - "묶음사진 전체 저장"을 선택 시 `pageImages`의 모든 이미지들을 저장
        - "이 사진만 저장"을 선택 시 `previewImageView`의 이미지만 저장
3. 이미지 저장 플로우의 변경에 따른 토스트 메세지의 내용 변경
    - "묶음사진 전체 저장"을 선택 시 -> "모든 루트파인딩을 사진에 저장했습니다" 라는 토스트메세지 출력
    - "이 사진만 저장"을 선택 시 -> "이 루트파인딩을 사진에 저장했습니다" 라는 토스트메세지 출력

### 관련 이슈
- #350 

### 작업의 결과물
|액션시트 출력|"묶음 사진 전체 저장" 토스트메세지|"이 사진만 저장" 토스트메세지|
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/45965405/205076519-05660c11-a03a-403c-a436-a4cd4bc70c62.PNG"  width="250">|<img src="https://user-images.githubusercontent.com/45965405/205076661-2597bd47-ae2c-450b-a305-372414e0fe54.PNG"  width="250">|<img src="https://user-images.githubusercontent.com/45965405/205076757-c6ebefae-796a-4636-b2f5-e4a732d4b4a3.PNG"  width="250">|

Close #350 
