### PR TITLE
[#355] fix - tabbar color 를 변경하였습니다.

### DIFF
--- a/OrrRock/OrrRock/AppDelegate.swift
+++ b/OrrRock/OrrRock/AppDelegate.swift
@@ -13,12 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        let appearance = UITabBarAppearance()
-        let tabBar = UITabBar()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor.orrGray050Custom
-        tabBar.standardAppearance = appearance
-        UITabBar.appearance().scrollEdgeAppearance = appearance
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithDefaultBackground()
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
         return true
     }
     


### PR DESCRIPTION
### 작업 내용 설명
1. 탭바 색상 변경


### 관련 이슈
- #355

### 작업의 결과물
|수정 전|수정 후|
|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/205042697-4a1e383e-71c7-4336-acee-3f193828fac0.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/72395020/205083762-cc2356cf-6d46-4a41-9b6e-2fa179d23d83.jpeg">|

### 작업의 비고사항 및 한계점
- ios 15에 들어서면서 scrollEdgeAppearance를 따로 지정해주지 않으면 탭바가 투명한색으로 변경되는 기능이 추가가되었습니다. 이를 해결하기 위해 appdelegate부분에 전체적으로 uitabbar 의 apperance를 지정해주었습니다.
- 참고 (https://stackoverflow.com/questions/69467580/transparent-tabbar-when-popping-child-navigationview-ios-15)

### To Reviewers
- 감사합니다.

Close #355 
