### PR TITLE
[#357] fix - 루트파인딩 메인 뷰 썸네일과 detailView 컨텐츠 불일치 

### DIFF
--- a/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController+Extensions.swift
+++ b/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController+Extensions.swift
@@ -69,7 +69,7 @@ extension RouteFindingSectionViewController: UICollectionViewDataSource {
             routeFindingCollectionView.deselectItem(at: indexPath, animated: true)
             //화면이동 로직 들어갈 부분
             let index = indexPath.row
-            guard let route = routeFindingDataManager?.getRouteFindingList()[index] else { return }
+            let route = routeInformations[index]
 
             let routeDataDraft = RouteDataDraft(manager: routeFindingDataManager!, existingRouteFinding: route, imageLocalIdentifier: route.imageLocalIdentifier)
             let vc = RouteFindingDetailViewController(routeDataDraft: routeDataDraft)


### PR DESCRIPTION
### 작업 내용 설명
1. 루트파인딩 메인 뷰 썸네일과 detailView 컨텐츠 불일치를 해결했습니다.


### 관련 이슈
- #357 

### 작업의 비고사항 및 한계점
- 비고사항 및 한계점이 없다면 기록 X

### To Reviewers
- 감사합니다.

Close #357
