### PR TITLE
[#367] fix - 루트 파인딩 메인뷰 바텀 옵션뷰 높이 이슈

### DIFF
--- a/OrrRock/OrrRock/RouteFinding/RouteFindingMainViewController.swift
+++ b/OrrRock/OrrRock/RouteFinding/RouteFindingMainViewController.swift
@@ -95,7 +95,6 @@ final class RouteFindingMainViewController: UIViewController {
         setUpLayout()
         setInitialNavigationBar()
         setUpSegment()
-        
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -127,6 +126,7 @@ final class RouteFindingMainViewController: UIViewController {
     
     private func setUpLayout(){
         view.backgroundColor = .orrGray050
+        UserDefaults.standard.set(tabBarController!.tabBar.frame.size.height, forKey: "tabBarHeight")
         
         view.addSubview(topView)
         topView.snp.makeConstraints {

--- a/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController.swift
+++ b/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController.swift
@@ -149,7 +149,7 @@ class RouteFindingSectionViewController: UIViewController {
         bottomOptionView.snp.makeConstraints {
             $0.bottom.equalToSuperview()
             $0.leading.trailing.equalToSuperview()
-            $0.top.equalTo(view.snp_bottomMargin)
+            $0.height.equalTo(UserDefaults.standard.double(forKey: "tabBarHeight"))
         }
         
         bottomOptionView.addSubview(folderButton)
@@ -209,7 +209,6 @@ class RouteFindingSectionViewController: UIViewController {
     }
     
     private func initRouteInformations() {
-        print("inittt")
         switch sectionKind{
         case .all:
             routeInformations = routeFindingDataManager?.getRouteFindingList().sorted { $1.dataWrittenDate < $0.dataWrittenDate }
@@ -220,6 +219,5 @@ class RouteFindingSectionViewController: UIViewController {
         case .none:
             break
         }
-        
     }
 }


### PR DESCRIPTION
### 작업 내용 설명
1. 루트 파인딩 메인뷰 모달 높이 이슈가 있습니다. 
    앱이 백그라운드로 진입하고 재진입시에 바텀 옵션뷰 높이가 의도하지 않았던 높이로 설정됩니다.
2. 임시방편으로 userdefault를 사용하여 값을 받아와 저장하였습니다.


### 관련 이슈
- #367



### To Reviewers
- 감사합니다.

Close #367 
