### PR TITLE
[#359] fix - 루트파인딩 디테일 페이지 수, 썸네일 수 불일치 개선

### DIFF
--- a/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController.swift
+++ b/OrrRock/OrrRock/RouteFinding/RouteFindingSectionViewController.swift
@@ -209,7 +209,6 @@ class RouteFindingSectionViewController: UIViewController {
     }
     
     private func initRouteInformations() {
-        print("inittt")
         switch sectionKind{
         case .all:
             routeInformations = routeFindingDataManager?.getRouteFindingList().sorted { $1.dataWrittenDate < $0.dataWrittenDate }

--- a/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController+CollectionViewExtensions.swift
+++ b/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController+CollectionViewExtensions.swift
@@ -14,7 +14,6 @@ extension RouteFindingDetailViewController: UICollectionViewDataSource {
         
         let centerPoint = CGPoint(x: self.thumbnailCollectionView.frame.size.width / 2 + scrollView.contentOffset.x,
                                   y: self.thumbnailCollectionView.frame.size.height / 2 + scrollView.contentOffset.y)
-        
         // 화면 가운데에 셀의 indexPath에 대해
         if let indexPath = thumbnailCollectionView.indexPathForItem(at: centerPoint) {
             // 가운데 셀을 선택

--- a/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController.swift
@@ -45,8 +45,6 @@ class RouteFindingDetailViewController: UIViewController {
     private lazy var routePageViewController: UIPageViewController = {
         let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
         pageViewController.view.backgroundColor = .black
-        
-        pageViewController.setViewControllers([RouteViewController(pageInfo: routeDataDraft.routeInfoForUI.pages[0], backgroundImage: routeDataDraft.routeInfoForUI.imageLocalIdentifier.generateCardViewThumbnail()!)], direction: .forward, animated: true)
         pageViewController.isPagingEnabled = false
         return pageViewController
     }()
@@ -83,10 +81,8 @@ class RouteFindingDetailViewController: UIViewController {
         setUpCollectionView()
         addUIGesture()
         
-        loadPageViewControllerList()
         let tapgesture = UITapGestureRecognizer(target: self, action: #selector(respondToTapGesture(_:)))
         view.addGestureRecognizer(tapgesture)
-        
     }
     
     required init?(coder: NSCoder) {
@@ -153,7 +149,6 @@ class RouteFindingDetailViewController: UIViewController {
     
     func getViewControllerForPageVC() -> [RouteViewController] {
         var routeViewControllers: [RouteViewController] = []
-        
         routeDataDraft.routeInfoForUI.pages.forEach { pageInfo in
             routeViewControllers.append(RouteViewController(pageInfo: pageInfo, backgroundImage: routeDataDraft.routeInfoForUI.imageLocalIdentifier.generateCardViewThumbnail(targetSize: CGSize(width: 2400, height: 2400))!))
         }
@@ -292,7 +287,6 @@ extension RouteFindingDetailViewController {
         viewControllerListForPageVC = getViewControllerForPageVC()
         routePageViewController.setViewControllers([viewControllerListForPageVC.first!], direction: .forward, animated: true)
         thumbnailCollectionView.reloadData()
-        
     }
     
     private func setUpCollectionView() {

--- a/OrrRock/OrrRock/RouteFindingDetail/RoutefindingDetailViewController+UIPageViewControllerExtensions.swift
+++ b/OrrRock/OrrRock/RouteFindingDetail/RoutefindingDetailViewController+UIPageViewControllerExtensions.swift
@@ -47,7 +47,6 @@ extension RouteFindingDetailViewController: UIPageViewControllerDelegate {
           let currentVC = pageViewController.viewControllers?.first,
           let index = viewControllerListForPageVC.firstIndex(of: currentVC) else { return }
         
-//        print("index : \(index)")
         thumbnailCollectionView.scrollToItem(at: IndexPath(row: index, section: 0), at: .centeredHorizontally, animated: true)
 
       }


### PR DESCRIPTION
### 작업 내용 설명
**1. `RouteFindingDetailViewController` 의 `PageViewController` 오류 수정**

### 관련 이슈
- #359 

### 작업의 결과물
- `viewDidLoad` 및 `lazy var routePageViewController`에서 사용하던 `PageViewController`의 첫번째 VC를 지정해주는 구문 제거 후 정상 동작하는 것을 확인했습니다.
![](https://user-images.githubusercontent.com/96641477/205136773-665f785a-9714-44d7-9986-7a6f99e739c8.MP4)

### 작업의 비고사항 및 한계점
- 비고사항 및 한계점이 없다면 기록 X

### To Reviewers
- 자러가보겠습니다 :)

Close #359
