### PR TITLE
[#372] fix - 뷰 파란색 영역 중복 출현 이슈 해결

### DIFF
--- a/OrrRock/OrrRock/AppDelegate.swift
+++ b/OrrRock/OrrRock/AppDelegate.swift
@@ -13,12 +13,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        let appearance = UITabBarAppearance()
-        let tabBar = UITabBar()
-        appearance.configureWithOpaqueBackground()
-        appearance.backgroundColor = UIColor.orrGray050Custom
-        tabBar.standardAppearance = appearance
-        UITabBar.appearance().scrollEdgeAppearance = appearance
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithDefaultBackground()
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
         return true
     }
     

--- a/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingDetail/RouteFindingDetailViewController.swift
@@ -113,7 +113,7 @@ class RouteFindingDetailViewController: UIViewController {
         self.thumbnailCollectionView.contentInset = UIEdgeInsets(top: 0, left: sideInset, bottom: 0, right: sideInset)
         
         // 뷰가 올라오면 가장 처음 페이지로 이동
-        thumbnailCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: false)
+        thumbnailCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: true)
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
@@ -228,7 +228,7 @@ final class RouteFindingFeatureViewController: UIViewController {
         self.thumbnailCollectionView.contentInset = UIEdgeInsets(top: 0, left: sideInset, bottom: 0, right: sideInset)
         
         // 뷰가 올라오면 가장 처음 페이지로 이동
-        thumbnailCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: false)
+        thumbnailCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: true)
     }
     
     override func viewWillDisappear(_ animated: Bool) {

--- a/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
+++ b/OrrRock/OrrRock/SaveRootFinding/RouteFindingSaveViewController.swift
@@ -171,7 +171,7 @@ class RouteFindingSaveViewController: UIViewController {
         let sideInset = self.view.frame.width / 2 - layoutMargins
         self.saveRouteFindingImageCollectionView.contentInset = UIEdgeInsets(top: 0, left: sideInset, bottom: 0, right: sideInset)
         
-        saveRouteFindingImageCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: false)
+        saveRouteFindingImageCollectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .centeredHorizontally, animated: true)
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### 작업 내용 설명
1. 세번째 뷰에서 파란 밑줄이 생기는 이슈 해결
    - 가운데에 위치한 셀 (선택된 셀)에 `selecBar`가 생성되는 로직으로 구현되어있었음
    - 처음 뷰가 로드될 때 세번째 있는 셀이 가운데에 있다가 뷰가 나타날 때 셀이 밀리면서 `selectBar`가 두개가 되는 이슈가 생김
    - `animated` 파라미터를 `true`로 주면서 뷰가 밀리는 과정에서 `selectBar`도 함께 밀리게 구현함으로써 이슈 해결

### 관련 이슈
- #372 

### To Reviewer
- 이슈 해결에 큰 도움을 주신 @sm-amoled 에게 감사를 드립니다~

Close #372 
