### PR TITLE
[#384] design - RouteFinding X 버튼 SFSymbol로 교체

### DIFF
--- a/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingFeature/RouteFindingFeatureViewController.swift
@@ -90,10 +90,9 @@ final class RouteFindingFeatureViewController: UIViewController {
         let button = UIButton(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
         button.layer.cornerRadius = 20
         button.backgroundColor = .orrGray700
-        button.setImage(UIImage(systemName: "multiply"), for: .normal)
-        button.contentVerticalAlignment = .fill
-        button.contentHorizontalAlignment = .fill
-        button.imageEdgeInsets = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+        let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .medium, scale: .small)
+        let buttonSymbol = UIImage(systemName: "xmark", withConfiguration: config)?.withTintColor(UIColor.white, renderingMode: .alwaysOriginal)
+        button.setImage(buttonSymbol, for: .normal)
         button.tintColor = .orrWhite
         button.addAction(UIAction { _ in
             self.showExitAlert()

--- a/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
+++ b/OrrRock/OrrRock/RouteFindingUpload/RouteFindingCameraViewController.swift
@@ -56,7 +56,7 @@ final class RouteFindingCameraViewController: UIViewController {
         button.backgroundColor = UIColor.black.withAlphaComponent(0.3)
         button.layer.cornerRadius = 20
         let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .medium, scale: .small)
-        let buttonSymbol = UIImage(systemName: "multiply", withConfiguration: config)?.withTintColor(UIColor.white, renderingMode: .alwaysOriginal)
+        let buttonSymbol = UIImage(systemName: "xmark", withConfiguration: config)?.withTintColor(UIColor.white, renderingMode: .alwaysOriginal)
         button.setImage(buttonSymbol, for: .normal)
         
         button.addTarget(self, action: #selector(dismissRouteFinidngCameraViewController), for: .touchUpInside)


### PR DESCRIPTION
### 작업 내용 설명
1. RouteFindingFeatureViewController `multiply X` -> `xmark X`로 수정하기
2. RouteFindingCameraViewController `multiply X` -> `xmark X`로 수정하기

### 관련 이슈
- #384

### 작업의 결과물
|RouteFindingCameraVC|RouteFindingFeatureVC|
|:---:|:---:|
|![IMG_3962](https://user-images.githubusercontent.com/96641477/205621807-f68cd2bb-a05e-4aff-b176-ecc27e8ffc11.PNG)|![IMG_3963](https://user-images.githubusercontent.com/96641477/205621818-f44dd133-7934-454b-9f62-ee9d7e9892ce.PNG)|

Close #384 