### PR TITLE
[#400] fix 카드분류 다른 종류 버튼 연타 크래쉬 해결

### DIFF
--- a/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
+++ b/OrrRock/OrrRock/Upload/LevelAndPFSettingViewController.swift
@@ -102,6 +102,7 @@ final class LevelAndPFSettingViewController: UIViewController {
         let button = CustomButton()
         button.setImage(UIImage(named: "fail_icon"), for: .normal)
         button.layer.cornerRadius = 37.0
+        button.isExclusiveTouch = true
         button.addTarget(self, action: #selector(didFailButton), for: .touchUpInside)
         
         return button
@@ -111,6 +112,7 @@ final class LevelAndPFSettingViewController: UIViewController {
         let button = CustomButton()
         button.setImage(UIImage(named: "delete"), for: .normal)
         button.layer.cornerRadius = 37.0
+        button.isExclusiveTouch = true
         button.addTarget(self, action: #selector(didDeleteButton), for: .touchUpInside)
         
         return button
@@ -121,6 +123,7 @@ final class LevelAndPFSettingViewController: UIViewController {
         let button = CustomButton()
         button.setImage(UIImage(named: "success_icon"), for: .normal)
         button.layer.cornerRadius = 37.0
+        button.isExclusiveTouch = true
         button.addTarget(self, action: #selector(didSuccessButton), for: .touchUpInside)
         return button
     }()


### PR DESCRIPTION
### 작업 내용 설명
1. 카드 분류 화면에서 다른 버튼 연타 시 앱이 종료되는 버그 수정

### 관련 이슈
- #400 

### 작업의 결과물
#### 문제 화면 
자세히 보면 성공 실패 버튼이 동시에 클릭 되어 종료된 모습입니다.

https://user-images.githubusercontent.com/103024840/206658529-2b8d51d3-9622-4d0c-ad05-f3dd95fc777c.mp4

#### 개선 화면 
연타를 하여도 정상 인식 됩니다.

https://user-images.githubusercontent.com/103024840/206658494-e236ce71-3cea-482f-aab0-47c63f0169f1.mp4



### 작업의 비고사항 및 한계점
- 저에게 한계란 없습니다.

### To Reviewers
- 기존 앱 카드 분류화면에서 다른 버튼 동시에 연타하면 버그 구현 가능합니다.

Close #400


